### PR TITLE
Feature/ibis execution api

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ sql = build_cohort_query(cohort, options)
 print(sql)
 ```
 
+### Experimental Ibis Execution API
+
+An experimental backend-native execution API is available under
+`circe.execution`.
+
+```python
+from circe.execution import ExecutionOptions, IbisExecutor
+
+# Requires optional extras, e.g. `pip install ohdsi-circe-python-alpha[ibis-duckdb]`
+executor = IbisExecutor(conn, ExecutionOptions(cdm_schema="main"))
+events = executor.build(cohort)  # lazy ibis relation
+```
+
 ## What's Included
 
 This package provides a complete Python implementation of CIRCE-BE with:
@@ -181,6 +194,7 @@ circe/
 │   ├── operations/            # Check operations
 │   ├── utils/                 # Check utilities
 │   └── warnings/              # Warning classes
+├── execution/                 # Experimental backend-native execution APIs
 ├── helper/                    # Utility helper classes
 ├── api.py                     # High-level API functions
 └── cli.py                     # Command-line interface

--- a/circe/__init__.py
+++ b/circe/__init__.py
@@ -24,39 +24,83 @@ __author__ = "CIRCE Python Implementation Team"
 __email__ = "circe-python@ohdsi.org"
 __license__ = "Apache License 2.0"
 
-# Main exports
-from .cohortdefinition import CohortExpression
-from .vocabulary import Concept, ConceptSet, ConceptSetExpression, ConceptSetItem
-from .api import (
-    cohort_expression_from_json,
-    build_cohort_query,
-    cohort_print_friendly,
-)
-
-from circe.cohortdefinition import (
-    CohortExpression, Criteria, CorelatedCriteria, DemographicCriteria,
-    Occurrence, CriteriaColumn, InclusionRule, CollapseType, DateType,
-    ResultLimit, Period, DateRange, NumericRange, DateAdjustment,
-    ObservationFilter, CollapseSettings, EndStrategy, PrimaryCriteria,
-    CriteriaGroup, ConceptSetSelection, Window, TextFilter, GeoCriteria, WindowedCriteria,
-    DateOffsetStrategy, CustomEraStrategy, ConditionOccurrence, DrugExposure,
-    InclusionRule, WindowBound,
-    ProcedureOccurrence, VisitOccurrence, Observation, Measurement, DeviceExposure,
-    Specimen, Death, VisitDetail, ObservationPeriod, PayerPlanPeriod, LocationRegion,
-    ConditionEra, DrugEra, DoseEra
-)
-
-from typing import Dict
+import importlib
+import inspect
+import pkgutil
 
 # ---------------------------------------------------------------------
 # Embedded interpreter (e.g. R reticulate) bootstrapping for Pydantic
 # ---------------------------------------------------------------------
 import sys
-import pkgutil
-import importlib
-import inspect
+from typing import Dict
+
 from pydantic import BaseModel
+
 import circe as package
+from circe.cohortdefinition import (
+    CohortExpression,
+    CollapseSettings,
+    CollapseType,
+    ConceptSetSelection,
+    ConditionEra,
+    ConditionOccurrence,
+    CorelatedCriteria,
+    Criteria,
+    CriteriaColumn,
+    CriteriaGroup,
+    CustomEraStrategy,
+    DateAdjustment,
+    DateOffsetStrategy,
+    DateRange,
+    DateType,
+    Death,
+    DemographicCriteria,
+    DeviceExposure,
+    DoseEra,
+    DrugEra,
+    DrugExposure,
+    EndStrategy,
+    GeoCriteria,
+    InclusionRule,
+    LocationRegion,
+    Measurement,
+    NumericRange,
+    Observation,
+    ObservationFilter,
+    ObservationPeriod,
+    Occurrence,
+    PayerPlanPeriod,
+    Period,
+    PrimaryCriteria,
+    ProcedureOccurrence,
+    ResultLimit,
+    Specimen,
+    TextFilter,
+    VisitDetail,
+    VisitOccurrence,
+    Window,
+    WindowBound,
+    WindowedCriteria,
+)
+
+from .api import (
+    build_cohort_query,
+    cohort_expression_from_json,
+    cohort_print_friendly,
+)
+
+# Main exports
+from .cohortdefinition import CohortExpression
+from .execution import (
+    ExecutionOptions,
+    IbisExecutor,
+    build_ibis,
+    to_polars,
+    write_cohort,
+)
+from .io import load_expression
+from .vocabulary import Concept, ConceptSet, ConceptSetExpression, ConceptSetItem
+
 
 def safe_model_rebuild(package):
     """
@@ -88,7 +132,6 @@ def safe_model_rebuild(package):
                         pass
     except Exception:
         pass
-
 
 
 def get_json_schema() -> dict:
@@ -142,7 +185,7 @@ def get_json_schema() -> dict:
         "Window": Window,
         "TextFilter": TextFilter,
         "InclusionRule": InclusionRule,
-        "WindowBound": WindowBound
+        "WindowBound": WindowBound,
     }
 
     # Build root-level $defs with each schema
@@ -163,12 +206,9 @@ def get_json_schema() -> dict:
         "version": "1.3.3",
         "type": "object",
         "$defs": defs,
-        "properties": {
-            "CohortExpression": {"$ref": "#/$defs/CohortExpression"}
-        },
-        "required": ["CohortExpression"]
+        "properties": {"CohortExpression": {"$ref": "#/$defs/CohortExpression"}},
+        "required": ["CohortExpression"],
     }
-
 
 
 # ---------------------------------------------------------------------
@@ -181,10 +221,20 @@ __all__ = [
     "CohortExpression",
     "get_json_schema",
     # Vocabulary classes
-    "Concept", "ConceptSet", "ConceptSetExpression", "ConceptSetItem",
+    "Concept",
+    "ConceptSet",
+    "ConceptSetExpression",
+    "ConceptSetItem",
     # API functions
     "cohort_expression_from_json",
     "build_cohort_query",
     "cohort_print_friendly",
-    "safe_model_rebuild"
+    "safe_model_rebuild",
+    # I/O and experimental execution API
+    "load_expression",
+    "ExecutionOptions",
+    "IbisExecutor",
+    "build_ibis",
+    "to_polars",
+    "write_cohort",
 ]

--- a/circe/execution/__init__.py
+++ b/circe/execution/__init__.py
@@ -1,0 +1,13 @@
+"""Experimental backend execution APIs."""
+
+from .ibis import IbisExecutor, build_ibis, to_polars, write_cohort
+from .options import ExecutionOptions, SchemaName
+
+__all__ = [
+    "ExecutionOptions",
+    "SchemaName",
+    "IbisExecutor",
+    "build_ibis",
+    "to_polars",
+    "write_cohort",
+]

--- a/circe/execution/build_context.py
+++ b/circe/execution/build_context.py
@@ -1,0 +1,601 @@
+from __future__ import annotations
+
+import uuid
+import weakref
+from dataclasses import dataclass
+from functools import reduce
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Tuple, Union
+
+import ibis
+import ibis.common.exceptions as ibis_exc
+import ibis.expr.types as ir
+
+from ..vocabulary.concept import ConceptSet
+from .ibis_compat import table_from_literal_list
+
+Database = Union[str, Tuple[str, str]]
+
+
+def _qualify(database: Database | None, name: str) -> str:
+    """Only for statements were constructing outside of Ibis."""
+    if database is None:
+        return name
+    if isinstance(database, tuple):
+        return ".".join(database + (name,))
+    return f"{database}.{name}"
+
+
+def _table(conn: ibis.BaseBackend, database: Database | None, name: str) -> ir.Table:
+    return conn.table(name, database=database)
+
+
+def _warn(message: str) -> None:
+    print(f"Warning: {message}")
+
+
+def _analyze_table(
+    conn: ibis.BaseBackend, *, backend: str | None, qualified_name: str
+) -> None:
+    if not backend:
+        return
+    if backend in ("postgres", "duckdb"):
+        conn.raw_sql(f"ANALYZE {qualified_name}")
+        return
+    if backend == "databricks":
+        conn.raw_sql(f"ANALYZE TABLE {qualified_name} COMPUTE STATISTICS")
+
+
+def _drop_table_safely(
+    conn: ibis.BaseBackend,
+    *,
+    name: str,
+    database: Database | None = None,
+    warning_label: str,
+) -> None:
+    try:
+        conn.drop_table(name, database=database, force=True)
+    except Exception as exc:
+        _warn(f"could not drop {warning_label}: {exc}")
+
+
+@dataclass(frozen=True)
+class CohortBuildOptions:
+    cdm_schema: Optional[str] = None
+    vocabulary_schema: Optional[str] = None
+    result_schema: Optional[str] = None
+    target_table: Optional[str] = None
+    cohort_id: Optional[int] = None
+    generate_stats: bool = False
+    temp_emulation_schema: Optional[str] = None
+    profile_dir: Optional[str] = None
+    capture_sql: bool = False
+    backend: Optional[str] = None
+    materialize_stages: bool = True
+    materialize_codesets: bool = True
+
+
+@dataclass
+class CodesetResource:
+    table: ir.Table
+    _dropper: Optional[Callable[[], None]] = None
+
+    def cleanup(self):
+        if self._dropper:
+            try:
+                self._dropper()
+            finally:
+                self._dropper = None
+
+
+class BuildContext:
+    """Holds shared state (connection, schemas, compiled codesets) used across builders."""
+
+    def __init__(
+        self,
+        conn: ibis.BaseBackend,
+        options: CohortBuildOptions,
+        codeset_resource: CodesetResource | ir.Table,
+    ):
+        self._conn = conn
+        self._options = options
+        if isinstance(codeset_resource, CodesetResource):
+            self._codeset_resource = codeset_resource
+        else:
+            self._codeset_resource = CodesetResource(table=codeset_resource)
+        self._codesets = self._codeset_resource.table
+        self._cleanup_callbacks: list[Callable[[], None]] = []
+        self._correlated_cache: dict[str, ir.Table] = {}
+        self._profile_dir = None
+        if options.profile_dir:
+            path = Path(options.profile_dir).resolve()
+            path.mkdir(parents=True, exist_ok=True)
+            self._profile_dir = path
+        self._captured_sql: list[tuple[str, str]] = []
+        self._slice_cache: dict[str, ir.Table] = {}
+        weakref.finalize(self, self.close)
+
+    def _table(self, database: Optional[str], name: str) -> ir.Table:
+        try:
+            return _table(self._conn, database, name)
+        except (
+            ibis_exc.IbisError,
+            TypeError,
+            ValueError,
+            AttributeError,
+            NotImplementedError,
+        ):
+            return self._conn.sql(f"SELECT * FROM {_qualify(database, name)}")
+
+    def table(self, name: str) -> ir.Table:
+        """Return a CDM table."""
+        return self._table(self._options.cdm_schema, name)
+
+    def vocabulary_table(self, name: str) -> ir.Table:
+        """Return a vocabulary table (concept, concept_ancestor, etc.)."""
+        schema = self._options.vocabulary_schema or self._options.cdm_schema
+        return self._table(schema, name)
+
+    def codeset(self, codeset_id: int, *, is_exclusion: bool = False) -> ir.Table:
+        """Return concepts for the requested codeset. `is_exclusion` is provided for parity with Circe."""
+        _ = is_exclusion  # placeholder for future differentiated handling
+        return self._codesets.filter(self._codesets.codeset_id == codeset_id)
+
+    def get_cached_correlated(self, key: str) -> ir.Table | None:
+        return self._correlated_cache.get(key)
+
+    def cache_correlated(self, key: str, table: ir.Table) -> None:
+        self._correlated_cache[key] = table
+
+    def materialize(
+        self,
+        expr: ir.Table,
+        *,
+        label: str,
+        temp: bool = True,
+        analyze: bool = True,
+    ) -> ir.Table:
+        """
+        Materialize an Ibis expression, capturing a unique DuckDB profiling
+        artifact for this step.
+        """
+        step_id = uuid.uuid4().hex[:8]
+        table_name = f"_stage_{label}_{step_id}"
+        backend = self._options.backend
+
+        # "temp emulation" means: create a *real* table in a chosen database/schema.
+        use_temp_emulation = temp and self._options.temp_emulation_schema is not None
+        database: Database | None = (
+            self._options.temp_emulation_schema if use_temp_emulation else None
+        )
+        temp_flag = False if use_temp_emulation else temp
+
+        # duckdb profiling setup for local dev
+        profile_filename: Path | None = None
+        profiling_enabled = False
+        if backend == "duckdb" and self._profile_dir is not None:
+            profile_filename = (
+                self._profile_dir / f"ibis_profile_{label}_{step_id}.json"
+            ).resolve()
+            try:
+                escaped = str(profile_filename).replace("'", "''")
+                self._conn.raw_sql(f"SET profiling_output='{escaped}'")
+                self._conn.raw_sql("SET enable_profiling='json'")
+                self._conn.raw_sql("SET profiling_coverage='ALL'")
+                profiling_enabled = True
+            except Exception as exc:
+                _warn(f"could not enable DuckDB profiling for {label}: {exc}")
+
+        try:
+            self._conn.create_table(
+                table_name,
+                obj=expr,
+                database=database,
+                temp=temp_flag,
+                overwrite=True,
+            )
+            if self._options.capture_sql:
+                self._captured_sql.append((table_name, self._conn.compile(expr)))
+        finally:
+            if profiling_enabled:
+                try:
+                    self._conn.raw_sql("PRAGMA disable_profiling")
+                except Exception as exc:
+                    _warn(f"could not disable DuckDB profiling for {label}: {exc}")
+
+        if profiling_enabled and profile_filename is not None:
+            print(f"[Profile Captured]: {profile_filename} (Table: {table_name})")
+
+        if analyze:
+            qualified = _qualify(database, table_name)
+            try:
+                _analyze_table(self._conn, backend=backend, qualified_name=qualified)
+            except Exception as exc:
+                _warn(f"could not analyze table {qualified}: {exc}")
+
+        def _drop():
+            _drop_table_safely(
+                self._conn,
+                name=table_name,
+                database=database,
+                warning_label=f"table {table_name} in {database}",
+            )
+
+        self.register_cleanup(_drop)
+        return _table(self._conn, database, table_name)
+
+    def should_materialize_stages(self) -> bool:
+        return bool(self._options.materialize_stages)
+
+    def maybe_materialize(
+        self,
+        expr: ir.Table,
+        *,
+        label: str,
+        temp: bool = True,
+        analyze: bool = True,
+    ) -> ir.Table:
+        if not self.should_materialize_stages():
+            return expr
+        return self.materialize(expr, label=label, temp=temp, analyze=analyze)
+
+    def write_cohort_table(
+        self,
+        events: ir.Table,
+        *,
+        table_name: str | None = None,
+        database: Database | None = None,
+        overwrite: bool = True,
+        append: bool = False,
+    ) -> ir.Table:
+        """
+        Persist cohort rows to a results table.
+
+        Output schema matches OHDSI cohort tables:
+          (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+        """
+        target_table = table_name or self._options.target_table
+        if not target_table:
+            raise ValueError(
+                "target_table must be set (argument or CohortBuildOptions.target_table)"
+            )
+        target_db = database if database is not None else self._options.result_schema
+        if target_db is None:
+            raise ValueError(
+                "result_schema must be set (argument or CohortBuildOptions.result_schema)"
+            )
+
+        cohort_id = self._options.cohort_id
+        cohort_id_expr = (
+            ibis.literal(int(cohort_id), type="int64")
+            if cohort_id is not None
+            else ibis.null().cast("int64")
+        )
+
+        result = events.select(
+            cohort_id_expr.name("cohort_definition_id"),
+            events.person_id.cast("int64").name("subject_id"),
+            events.start_date.cast("date").name("cohort_start_date"),
+            events.end_date.cast("date").name("cohort_end_date"),
+        )
+
+        obj = result
+        if append:
+            try:
+                existing = _table(self._conn, target_db, target_table)
+                obj = existing.union(result, distinct=False)
+            except (
+                ibis_exc.IbisError,
+                TypeError,
+                ValueError,
+                AttributeError,
+                NotImplementedError,
+            ):
+                obj = result
+
+        self._conn.create_table(
+            target_table,
+            obj=obj,
+            database=target_db,
+            temp=False,
+            overwrite=overwrite,
+        )
+        return _table(self._conn, target_db, target_table)
+
+    @property
+    def codesets(self) -> ir.Table:
+        return self._codesets
+
+    @property
+    def conn(self) -> ibis.BaseBackend:
+        return self._conn
+
+    def options(self) -> CohortBuildOptions:
+        return self._options
+
+    def captured_sql(self) -> list[tuple[str, str]]:
+        return list(self._captured_sql)
+
+    def register_cleanup(self, callback: Callable[[], None]):
+        self._cleanup_callbacks.append(callback)
+
+    def get_or_materialize_slice(
+        self,
+        cache_key: str,
+        expr: ir.Table,
+        *,
+        label: str | None = None,
+    ) -> ir.Table:
+        """Materialize an expression once and reuse the resulting temp table for later lookups."""
+        if not self.should_materialize_stages():
+            return expr.view()
+        cached = self._slice_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        label_hint = label or "slice"
+        table = self.materialize(expr, label=label_hint, temp=True, analyze=True)
+        self._slice_cache[cache_key] = table
+        return table
+
+    def close(self):
+        if self._codeset_resource is not None:
+            self._codeset_resource.cleanup()
+            self._codeset_resource = None  # type: ignore[assignment]
+        while self._cleanup_callbacks:
+            callback = self._cleanup_callbacks.pop()
+            try:
+                callback()
+            except Exception as exc:
+                _warn(f"cleanup callback failed: {exc}")
+        self._captured_sql.clear()
+        self._slice_cache.clear()
+
+
+def compile_codesets(
+    conn: ibis.BaseBackend,
+    concept_sets: list[ConceptSet],
+    options: CohortBuildOptions,
+) -> CodesetResource:
+    """Rebuild Circe concept set logic as an ibis expression."""
+
+    vocab_schema = options.vocabulary_schema or options.cdm_schema
+    concept = _table(conn, vocab_schema, "concept")
+    concept_ancestor = _table(conn, vocab_schema, "concept_ancestor")
+    concept_relationship = _table(conn, vocab_schema, "concept_relationship")
+
+    compiled = []
+    for concept_set in concept_sets or []:
+        compiled_expr = _compile_single_codeset(
+            concept, concept_ancestor, concept_relationship, concept_set
+        )
+        if compiled_expr is not None:
+            compiled.append(compiled_expr)
+
+    if not compiled:
+        compiled_expr = _empty_codeset_table()
+    else:
+        compiled_expr = _union_all(compiled).distinct()
+
+    if not options.materialize_codesets:
+        return CodesetResource(table=compiled_expr)
+
+    return _materialize_codesets(conn, compiled_expr, options)
+
+
+def _compile_single_codeset(
+    concept: ir.Table,
+    concept_ancestor: ir.Table,
+    concept_relationship: ir.Table,
+    concept_set: ConceptSet,
+) -> Optional[ir.Table]:
+    expression = concept_set.expression
+    if expression is None or not expression.items:
+        return None
+
+    include_ids: list[int] = []
+    include_descendant_ids: list[int] = []
+    include_mapped_ids: list[int] = []
+    include_mapped_descendant_ids: list[int] = []
+
+    exclude_ids: list[int] = []
+    exclude_descendant_ids: list[int] = []
+    exclude_mapped_ids: list[int] = []
+    exclude_mapped_descendant_ids: list[int] = []
+
+    for item in expression.items:
+        if item.concept is None or item.concept.concept_id is None:
+            continue
+        target_include = not bool(item.is_excluded)
+        include_descendants = bool(item.include_descendants)
+        include_mapped = bool(item.include_mapped)
+        concept_id = int(item.concept.concept_id)
+
+        if target_include:
+            include_ids.append(concept_id)
+            if include_descendants:
+                include_descendant_ids.append(concept_id)
+            if include_mapped:
+                include_mapped_ids.append(concept_id)
+                if include_descendants:
+                    include_mapped_descendant_ids.append(concept_id)
+        else:
+            exclude_ids.append(concept_id)
+            if include_descendants:
+                exclude_descendant_ids.append(concept_id)
+            if include_mapped:
+                exclude_mapped_ids.append(concept_id)
+                if include_descendants:
+                    exclude_mapped_descendant_ids.append(concept_id)
+
+    include_expr = _union_distinct(
+        [
+            _ids_memtable(include_ids),
+            _descendants(concept, concept_ancestor, include_descendant_ids),
+            _mapped_concepts(
+                concept,
+                concept_ancestor,
+                concept_relationship,
+                include_mapped_ids,
+                include_mapped_descendant_ids,
+            ),
+        ]
+    )
+
+    if include_expr is None:
+        return None
+
+    exclude_expr = _union_distinct(
+        [
+            _ids_memtable(exclude_ids),
+            _descendants(concept, concept_ancestor, exclude_descendant_ids),
+            _mapped_concepts(
+                concept,
+                concept_ancestor,
+                concept_relationship,
+                exclude_mapped_ids,
+                exclude_mapped_descendant_ids,
+            ),
+        ]
+    )
+
+    if exclude_expr is not None:
+        include_expr = include_expr.anti_join(exclude_expr, ["concept_id"])
+
+    codeset_literal = ibis.literal(int(concept_set.id), type="int64")
+    return include_expr.mutate(codeset_id=codeset_literal)[["codeset_id", "concept_id"]]
+
+
+def _ids_memtable(ids: list[int]) -> Optional[ir.Table]:
+    if not ids:
+        return None
+    return table_from_literal_list(
+        ids, column_name="concept_id", element_type="int64"
+    ).distinct()
+
+
+def _descendants(
+    concept: ir.Table, concept_ancestor: ir.Table, ancestor_ids: list[int]
+) -> Optional[ir.Table]:
+    if not ancestor_ids:
+        return None
+    return (
+        concept_ancestor.filter(concept_ancestor.ancestor_concept_id.isin(ancestor_ids))
+        .join(concept, concept_ancestor.descendant_concept_id == concept.concept_id)
+        .filter(concept.invalid_reason.isnull())
+        .select(concept.concept_id.cast("int64").name("concept_id"))
+        .distinct()
+    )
+
+
+def _mapped_concepts(
+    concept: ir.Table,
+    concept_ancestor: ir.Table,
+    concept_relationship: ir.Table,
+    concepts_to_map: list[int],
+    concepts_with_descendants_to_map: list[int],
+) -> Optional[ir.Table]:
+    sources = _union_distinct(
+        [
+            _ids_memtable(concepts_to_map),
+            _descendants(concept, concept_ancestor, concepts_with_descendants_to_map),
+        ]
+    )
+
+    if sources is None:
+        return None
+
+    valid_relationships = concept_relationship.filter(
+        [
+            concept_relationship.relationship_id == "Maps to",
+            concept_relationship.invalid_reason.isnull(),
+        ]
+    )
+
+    return (
+        sources.join(
+            valid_relationships, sources.concept_id == valid_relationships.concept_id_2
+        )
+        .select(valid_relationships.concept_id_1.cast("int64").name("concept_id"))
+        .distinct()
+    )
+
+
+def _empty_codeset_table() -> ir.Table:
+    empty_concepts = table_from_literal_list(
+        [], column_name="concept_id", element_type="int64"
+    )
+    empty_codesets = empty_concepts.mutate(
+        codeset_id=ibis.null().cast("int64"),
+    )
+    return empty_codesets.select("codeset_id", "concept_id")
+
+
+def _materialize_codesets(
+    conn: ibis.BaseBackend,
+    expr: ir.Table,
+    options: CohortBuildOptions,
+) -> CodesetResource:
+    name = f"_codesets_{uuid.uuid4().hex}"
+    if options.temp_emulation_schema:
+        database: Database = options.temp_emulation_schema
+        conn.create_table(
+            name,
+            obj=expr,
+            database=database,
+            temp=False,
+            overwrite=True,
+        )
+        table = _table(conn, database, name)
+        qualified = _qualify(database, name)
+
+        def _drop():
+            _drop_table_safely(
+                conn,
+                name=name,
+                database=database,
+                warning_label=f"codeset table {name} in {database}",
+            )
+
+    else:
+        conn.create_table(
+            name,
+            obj=expr,
+            temp=True,
+            overwrite=True,
+        )
+        table = _table(conn, None, name)
+        qualified = _qualify(None, name)
+
+        def _drop():
+            _drop_table_safely(
+                conn,
+                name=name,
+                warning_label=f"codeset temp table {name}",
+            )
+
+    backend = options.backend
+    if backend:
+        try:
+            _analyze_table(conn, backend=backend, qualified_name=qualified)
+        except Exception as exc:
+            _warn(f"could not analyze codeset table {qualified}: {exc}")
+
+    resource = CodesetResource(table=table, _dropper=_drop)
+    weakref.finalize(resource, resource.cleanup)
+    return resource
+
+
+def _union_distinct(tables: Iterable[Optional[ir.Table]]) -> Optional[ir.Table]:
+    valid_tables = [t for t in tables if t is not None]
+    if not valid_tables:
+        return None
+
+    return reduce(
+        lambda left, right: left.union(right, distinct=True),
+        valid_tables[1:],
+        valid_tables[0],
+    )
+
+
+def _union_all(tables: list[ir.Table]) -> ir.Table:
+    return reduce(lambda left, right: left.union(right), tables[1:], tables[0])

--- a/circe/execution/build_context.py
+++ b/circe/execution/build_context.py
@@ -254,6 +254,10 @@ class BuildContext:
         Output schema matches OHDSI cohort tables:
           (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
         """
+        if append and overwrite:
+            raise ValueError(
+                "`append=True` and `overwrite=True` cannot be used together."
+            )
         target_table = table_name or self._options.target_table
         if not target_table:
             raise ValueError(

--- a/circe/execution/builders/__init__.py
+++ b/circe/execution/builders/__init__.py
@@ -1,0 +1,17 @@
+from . import condition_era  # noqa: F401
+from . import condition_occurrence  # noqa: F401
+from . import death  # noqa: F401
+from . import device_exposure  # noqa: F401
+from . import dose_era  # noqa: F401
+from . import drug_era  # noqa: F401
+from . import drug_exposure  # noqa: F401
+from . import measurement  # noqa: F401
+from . import observation  # noqa: F401
+from . import observation_period  # noqa: F401
+from . import payer_plan_period  # noqa: F401
+from . import procedure_occurrence  # noqa: F401
+from . import specimen  # noqa: F401
+from . import visit_detail  # noqa: F401
+from . import visit_occurrence  # noqa: F401
+from .pipeline import build_primary_events  # noqa: F401
+from .registry import build_events, register  # noqa: F401

--- a/circe/execution/builders/common.py
+++ b/circe/execution/builders/common.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Sequence, cast
+
+import ibis
+import ibis.expr.types as ir
+from ibis.expr.api import row_number
+
+from ...cohortdefinition.core import (
+    CollapseSettings,
+    CollapseType,
+    ConceptSetSelection,
+    CustomEraStrategy,
+    DateOffsetStrategy,
+    DateRange,
+    EndStrategy,
+    NumericRange,
+    TextFilter,
+)
+from ...vocabulary.concept import Concept
+from ..build_context import BuildContext
+
+OutputFormatter = Callable[[ir.Table], ir.Table]
+
+
+def _person_subset(ctx: BuildContext, columns: list[str]) -> ir.Table:
+    person = ctx.table("person")
+    missing = [col for col in columns if col not in person.columns]
+    if missing:
+        raise ValueError(f"Person table missing required columns: {missing}")
+    return person.select(columns)
+
+
+def standardize_output(
+    table: ir.Table,
+    *,
+    primary_key: str,
+    start_column: str,
+    end_column: str,
+) -> ir.Table:
+    """Project and rename columns to the strict builder output contract."""
+    start_expr = table[start_column].cast("timestamp")
+    same_column = end_column == start_column
+    if same_column:
+        end_expr = start_expr
+        needs_offset = ibis.literal(True)
+    elif end_column in table.columns:
+        end_raw = table[end_column].cast("timestamp")
+        end_expr = ibis.coalesce(end_raw, start_expr).cast("timestamp")
+        needs_offset = end_raw.isnull()
+    else:
+        end_expr = start_expr
+        needs_offset = ibis.literal(True)
+    one_day = ibis.interval(days=1)
+    end_expr = ibis.ifelse(needs_offset, cast(Any, end_expr) + one_day, end_expr).cast(
+        "timestamp"
+    )
+    visit_expr = (
+        table.visit_occurrence_id.cast("int64")
+        if "visit_occurrence_id" in table.columns
+        else ibis.null().cast("int64")
+    ).name("visit_occurrence_id")
+    return table.select(
+        table.person_id.cast("int64").name("person_id"),
+        table[primary_key].cast("int64").name("event_id"),
+        start_expr.name("start_date"),
+        end_expr.name("end_date"),
+        visit_expr,
+    )
+
+
+def project_event_columns(
+    table: ir.Table,
+    *,
+    primary_key: str,
+    start_column: str,
+    end_column: str,
+    include_visit_occurrence: bool = False,
+) -> ir.Table:
+    keep = ["person_id", primary_key, start_column]
+    if end_column in table.columns:
+        keep.append(end_column)
+    elif include_visit_occurrence and start_column != end_column:
+        keep.append(end_column)
+    if include_visit_occurrence and "visit_occurrence_id" in table.columns:
+        keep.append("visit_occurrence_id")
+    unique_keep = [
+        col
+        for i, col in enumerate(keep)
+        if col in table.columns and col not in keep[:i]
+    ]
+    return table.select(*(table[col] for col in unique_keep))
+
+
+def apply_codeset_filter(
+    table: ir.Table,
+    concept_column: str,
+    codeset_id: Optional[int],
+    ctx: BuildContext,
+) -> ir.Table:
+    if codeset_id is None:
+        return table
+    base_columns = table.columns
+    left = table.view()
+    concepts = ctx.codesets.filter(
+        ctx.codesets["codeset_id"] == ibis.literal(codeset_id)
+    ).view()
+    joined = left.join(concepts, [left[concept_column] == concepts["concept_id"]])
+    return _project_columns(joined, base_columns)
+
+
+def apply_concept_set_selection(
+    table: ir.Table,
+    column: str,
+    selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    if selection is None or selection.codeset_id is None:
+        return table
+    base_columns = table.columns
+    left = table.view()
+    codeset_table = ctx.codesets.filter(
+        ctx.codesets["codeset_id"] == ibis.literal(selection.codeset_id)
+    ).view()
+    if selection.is_exclusion:
+        return left.anti_join(codeset_table, [left[column] == codeset_table.concept_id])
+    joined = left.join(codeset_table, [left[column] == codeset_table.concept_id])
+    return _project_columns(joined, base_columns)
+
+
+def coerce_concept_set_selection(
+    value: object | None,
+) -> Optional[ConceptSetSelection]:
+    if value is None:
+        return None
+    if isinstance(value, ConceptSetSelection):
+        return value
+    if hasattr(value, "codeset_id"):
+        return cast(ConceptSetSelection, value)
+    try:
+        return ConceptSetSelection(CodesetId=int(cast(Any, value)))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Unsupported concept set selection value: {value!r}") from exc
+
+
+def apply_concept_criteria(
+    table: ir.Table,
+    *,
+    column: str,
+    concepts: Sequence[Concept] | None,
+    selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+    exclude: bool = False,
+) -> ir.Table:
+    table = apply_concept_filters(table, column, concepts, exclude=exclude)
+    return apply_concept_set_selection(table, column, selection, ctx)
+
+
+def apply_date_range(
+    table: ir.Table, column: str, date_range: Optional[DateRange]
+) -> ir.Table:
+    if not date_range:
+        return table
+    expr = table[column]
+    if date_range.op.endswith("bt"):
+        lower = ibis.literal(date_range.value)
+        upper = ibis.literal(date_range.extent)
+        predicate = expr.between(lower, upper)
+        if date_range.op.startswith("!"):
+            predicate = ~predicate
+    else:
+        comparator = _map_operator(date_range.op)
+        operand = ibis.literal(date_range.value)
+        predicate = comparator(expr, operand)
+    return table.filter(predicate)
+
+
+def apply_numeric_range(
+    table: ir.Table, column, numeric_range: Optional[NumericRange]
+) -> ir.Table:
+    if not numeric_range or numeric_range.value is None:
+        return table
+    op = numeric_range.op or "eq"
+
+    expr = table[column] if isinstance(column, str) else column
+    if op.endswith("bt"):
+        lower = ibis.literal(numeric_range.value)
+        upper = ibis.literal(numeric_range.extent)
+        predicate = expr.between(lower, upper)
+        if op.startswith("!"):
+            predicate = ~predicate
+    else:
+        comparator = _map_operator(op)
+        operand = ibis.literal(numeric_range.value)
+        predicate = comparator(expr, operand)
+    return table.filter(predicate)
+
+
+def apply_text_filter(
+    table: ir.Table, column: str, text_filter: Optional[TextFilter]
+) -> ir.Table:
+    if not text_filter or not text_filter.text:
+        return table
+    op = text_filter.op or "contains"
+    negate = op.startswith("!")
+    core = op[1:] if negate else op
+    core = core.lower()
+    prefix = "%" if core in {"endswith", "contains"} else ""
+    suffix = "%" if core in {"startswith", "contains"} else ""
+    pattern = f"{prefix}{text_filter.text}{suffix}"
+    col_expr = cast(ir.StringValue, table[column])
+    predicate = col_expr.like(pattern)
+    if negate:
+        predicate = ~predicate
+    return table.filter(predicate)
+
+
+def apply_interval_range(
+    table: ir.Table,
+    start_column: str,
+    end_column: str,
+    interval_range: Optional[NumericRange],
+) -> ir.Table:
+    if not interval_range or interval_range.value is None:
+        return table
+
+    op = (interval_range.op or "gte").lower()
+    value = int(interval_range.value)
+    start = cast(Any, table[start_column])
+    end = table[end_column]
+
+    def _interval(days: int):
+        return ibis.interval(days=int(days))
+
+    if op.endswith("bt"):
+        if interval_range.extent is None:
+            raise ValueError("Between operator for interval range requires an extent")
+        lower = _interval(value)
+        upper = _interval(int(interval_range.extent))
+        predicate = (end >= start + lower) & (end <= start + upper)
+        if op.startswith("!"):
+            predicate = ~predicate
+        return table.filter(predicate)
+
+    target = _interval(value)
+    if op == "lt":
+        predicate = end < start + target
+    elif op == "lte":
+        predicate = end <= start + target
+    elif op == "gt":
+        predicate = end > start + target
+    elif op == "gte":
+        predicate = end >= start + target
+    elif op == "eq":
+        predicate = (end >= start + target) & (end < start + _interval(value + 1))
+    elif op == "!eq":
+        predicate = ~((end >= start + target) & (end < start + _interval(value + 1)))
+    else:
+        raise ValueError(f"Unsupported operator for interval range: {op}")
+
+    return table.filter(predicate)
+
+
+def _map_operator(op: str):
+    mapping = {
+        "lt": lambda a, b: a < b,
+        "lte": lambda a, b: a <= b,
+        "eq": lambda a, b: a == b,
+        "!eq": lambda a, b: a != b,
+        "gt": lambda a, b: a > b,
+        "gte": lambda a, b: a >= b,
+    }
+    if op not in mapping:
+        raise ValueError(f"Operator {op} not supported")
+    return mapping[op]
+
+
+def apply_concept_filters(
+    table: ir.Table,
+    column: str,
+    include_concepts: Sequence[Concept] | None,
+    exclude: bool = False,
+) -> ir.Table:
+    if not include_concepts:
+        return table
+    concept_ids = [c.concept_id for c in include_concepts if c.concept_id is not None]
+    if not concept_ids:
+        return table
+    predicate = table[column].isin(cast(Any, concept_ids))
+    if exclude:
+        predicate = ~predicate
+    return table.filter(predicate)
+
+
+def apply_age_filter(
+    table: ir.Table,
+    age_range: Optional[NumericRange],
+    ctx: BuildContext,
+    start_column: str,
+) -> ir.Table:
+    if not age_range:
+        return table
+    base_columns = table.columns
+    person = _person_subset(ctx, ["person_id", "year_of_birth"])
+    joined = table.join(person, ["person_id"])
+    start_expr = cast(ir.TimestampValue, _ensure_timestamp(joined[start_column]))
+    age_expr = start_expr.year() - cast(Any, joined.year_of_birth)
+    joined = joined.mutate(_criteria_age=age_expr)
+    filtered = apply_numeric_range(joined, "_criteria_age", age_range)
+    filtered = filtered.drop("_criteria_age")
+    return _project_columns(filtered, base_columns)
+
+
+def apply_gender_filter(
+    table: ir.Table,
+    genders: list[Concept] | None,
+    gender_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    return _apply_person_concept_filter(
+        table,
+        person_column="gender_concept_id",
+        concepts=genders,
+        selection=gender_selection,
+        ctx=ctx,
+    )
+
+
+def apply_race_filter(
+    table: ir.Table,
+    races: list[Concept] | None,
+    race_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    return _apply_person_concept_filter(
+        table,
+        person_column="race_concept_id",
+        concepts=races,
+        selection=race_selection,
+        ctx=ctx,
+    )
+
+
+def apply_ethnicity_filter(
+    table: ir.Table,
+    ethnicities: list[Concept] | None,
+    ethnicity_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    return _apply_person_concept_filter(
+        table,
+        person_column="ethnicity_concept_id",
+        concepts=ethnicities,
+        selection=ethnicity_selection,
+        ctx=ctx,
+    )
+
+
+def _apply_person_concept_filter(
+    table: ir.Table,
+    *,
+    person_column: str,
+    concepts: Sequence[Concept] | None,
+    selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    if not concepts and not selection:
+        return table
+    base_columns = table.columns
+    person = _person_subset(ctx, ["person_id", person_column])
+    joined = table.join(person, ["person_id"])
+    joined = apply_concept_criteria(
+        joined,
+        column=person_column,
+        concepts=concepts,
+        selection=selection,
+        ctx=ctx,
+    )
+    return _project_columns(joined, base_columns)
+
+
+def apply_observation_window(
+    events: ir.Table,
+    observation_window,
+    ctx: BuildContext,
+) -> ir.Table:
+    if observation_window is None:
+        return events
+    observation = ctx.table("observation_period").select(
+        "person_id", "observation_period_start_date", "observation_period_end_date"
+    )
+    # Use a view to ensure subsequent joins don't mix incompatible relations.
+    left = events.view()
+    joined = left.join(observation, ["person_id"])
+    prior_days = ibis.interval(days=int(observation_window.prior_days or 0))
+    post_days = ibis.interval(days=int(observation_window.post_days or 0))
+    start_col = _ensure_timestamp(joined.observation_period_start_date)
+    end_col = _ensure_timestamp(joined.observation_period_end_date)
+    start_bound = start_col + cast(Any, prior_days)
+    end_bound = end_col - cast(Any, post_days)
+    filtered = joined.filter(
+        (joined.start_date >= start_bound) & (joined.start_date <= end_bound)
+    )
+    base_projection = [filtered[col] for col in events.columns]
+    base_projection.extend(
+        filtered[col]
+        for col in ("observation_period_start_date", "observation_period_end_date")
+        if col in filtered.columns
+    )
+    return filtered.select(*base_projection)
+
+
+def apply_first_event(table: ir.Table, start_column: str, primary_key: str) -> ir.Table:
+    window = ibis.window(
+        group_by=table.person_id,
+        order_by=[table[start_column], table[primary_key]],
+    )
+
+    ranked = table.mutate(_row_num=row_number().over(window))
+    filtered = ranked.filter(ranked["_row_num"] == ibis.literal(0))
+    keep_columns = [col for col in table.columns if col != "_row_num"]
+    if keep_columns:
+        return filtered.select(*(filtered[col] for col in keep_columns))
+    return filtered.drop("_row_num")
+
+
+def apply_visit_concept_filters(
+    table: ir.Table,
+    visit_types: list[Concept] | None,
+    visit_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+) -> ir.Table:
+    return apply_concept_criteria(
+        table,
+        column="visit_concept_id",
+        concepts=visit_types,
+        selection=visit_selection,
+        ctx=ctx,
+    )
+
+
+def apply_provider_specialty_filter(
+    table: ir.Table,
+    provider_specialties: list[Concept] | None,
+    provider_specialty_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+    provider_column: str = "provider_id",
+) -> ir.Table:
+    if not provider_specialties and not provider_specialty_selection:
+        return table
+    provider = ctx.table("provider")
+    provider = apply_concept_criteria(
+        provider,
+        column="specialty_concept_id",
+        concepts=provider_specialties,
+        selection=provider_specialty_selection,
+        ctx=ctx,
+    )
+    filtered = provider.select(provider.provider_id)
+    return table.semi_join(filtered, [table[provider_column] == filtered.provider_id])
+
+
+def apply_care_site_filter(
+    table: ir.Table,
+    place_of_service_selection: Optional[ConceptSetSelection],
+    ctx: BuildContext,
+    care_site_column: str = "care_site_id",
+) -> ir.Table:
+    if not place_of_service_selection:
+        return table
+    care_site = ctx.table("care_site")
+    filtered = apply_concept_set_selection(
+        care_site, "place_of_service_concept_id", place_of_service_selection, ctx
+    )
+    filtered = filtered.select(filtered.care_site_id)
+    return table.semi_join(filtered, [table[care_site_column] == filtered.care_site_id])
+
+
+def apply_location_region_filter(
+    table: ir.Table,
+    *,
+    care_site_column: str,
+    location_codeset_id: Optional[int],
+    start_column: str,
+    end_column: str,
+    ctx: BuildContext,
+) -> ir.Table:
+    if not location_codeset_id:
+        return table
+    base_columns = table.columns
+    care_site = ctx.table("care_site")
+    location_history = ctx.table("location_history")
+    location = ctx.table("location")
+    joined = table.join(care_site, [table[care_site_column] == care_site.care_site_id])
+    start_expr = _ensure_timestamp(joined[start_column])
+    end_expr = _ensure_timestamp(joined[end_column])
+    lh = location_history
+    lh_condition = (
+        (joined[care_site_column] == lh.entity_id)
+        & (lh.domain_id == ibis.literal("CARE_SITE"))
+        & (start_expr >= lh.start_date)
+        & (
+            end_expr
+            <= ibis.coalesce(lh.end_date, ibis.literal("2099-12-31").cast("date"))
+        )
+    )
+    joined = joined.join(lh, [lh_condition])
+    joined = joined.join(location, [joined.location_id == location.location_id])
+    codeset = ctx.codesets.filter(
+        ctx.codesets.codeset_id == ibis.literal(location_codeset_id)
+    )
+    filtered = joined.join(codeset, [location.region_concept_id == codeset.concept_id])
+    return _project_columns(filtered, base_columns)
+
+
+def apply_user_defined_period(
+    table: ir.Table,
+    start_column: str,
+    end_column: str,
+    period,
+) -> tuple[ir.Table, str, str]:
+    if not period:
+        return table, start_column, end_column
+
+    base_start = table[start_column]
+    base_end = table[end_column]
+    additions = {}
+    new_start = start_column
+    new_end = end_column
+
+    if getattr(period, "start_date", None):
+        literal = _literal_like(period.start_date, base_start)
+        additions["_user_defined_start"] = literal
+        table = table.filter((base_start <= literal) & (base_end >= literal))
+        new_start = "_user_defined_start"
+
+    if getattr(period, "end_date", None):
+        literal = _literal_like(period.end_date, base_end)
+        additions["_user_defined_end"] = literal
+        table = table.filter((base_start <= literal) & (base_end >= literal))
+        new_end = "_user_defined_end"
+
+    if additions:
+        table = table.mutate(**additions)
+
+    return table, new_start, new_end
+
+
+def _literal_like(value, reference):
+    literal = ibis.literal(value)
+    dtype = reference.type()
+    if dtype.is_timestamp():
+        return literal.cast("timestamp")
+    if dtype.is_date():
+        return literal.cast("date")
+    return literal
+
+
+def _ensure_timestamp(expr: ir.Value) -> ir.Value:
+    dtype = expr.type()
+    if dtype.is_timestamp():
+        return expr
+    if dtype.is_date():
+        return expr.cast("timestamp")
+    if dtype.is_string():
+        return ibis.to_timestamp(expr)
+    raise ValueError(f"Cannot convert expression of type {dtype} to timestamp")
+
+
+def _cast_like(expr: ir.Value, reference: ir.Value) -> ir.Value:
+    target_type = reference.type()
+    if expr.type() == target_type:
+        return expr
+    return expr.cast(cast(Any, target_type))
+
+
+def _project_columns(table: ir.Table, column_names: Sequence[str]) -> ir.Table:
+    available = [name for name in column_names if name in table.columns]
+    if not available:
+        return table
+    return table.select(*[table[name] for name in available])
+
+
+def apply_end_strategy(
+    events: ir.Table,
+    strategy: Optional[EndStrategy | DateOffsetStrategy | CustomEraStrategy],
+    ctx: BuildContext,
+) -> ir.Table:
+    date_offset, custom_era = _resolve_end_strategy_parts(strategy)
+    if not date_offset and not custom_era:
+        if "observation_period_end_date" in events.columns:
+            op_end = _cast_like(
+                _ensure_timestamp(events.observation_period_end_date), events.end_date
+            )
+            return events.mutate(end_date=op_end)
+        return events
+    result = events
+    if custom_era:
+        result = _apply_custom_era_strategy(result, custom_era, ctx)
+    if date_offset:
+        interval = ibis.interval(days=int(date_offset.offset))
+        date_field = str(date_offset.date_field or "StartDate").lower()
+        anchor = (
+            _ensure_timestamp(result.start_date)
+            if date_field == "startdate"
+            else _ensure_timestamp(result.end_date)
+        )
+        shifted = anchor + cast(Any, interval)
+        if "observation_period_end_date" in result.columns:
+            shifted = ibis.least(
+                shifted,
+                _ensure_timestamp(result.observation_period_end_date),
+            )
+        result = result.mutate(end_date=_cast_like(shifted, result.end_date))
+    return result
+
+
+def has_end_strategy(
+    strategy: Optional[EndStrategy | DateOffsetStrategy | CustomEraStrategy],
+) -> bool:
+    date_offset, custom_era = _resolve_end_strategy_parts(strategy)
+    return bool(date_offset or custom_era)
+
+
+def _resolve_end_strategy_parts(
+    strategy: Optional[EndStrategy | DateOffsetStrategy | CustomEraStrategy],
+) -> tuple[Optional[DateOffsetStrategy], Optional[CustomEraStrategy]]:
+    if strategy is None:
+        return None, None
+
+    if isinstance(strategy, DateOffsetStrategy):
+        return strategy, None
+
+    if isinstance(strategy, CustomEraStrategy):
+        return None, strategy
+
+    date_offset = getattr(strategy, "date_offset", None)
+    custom_era = getattr(strategy, "custom_era", None)
+
+    if isinstance(date_offset, dict):
+        date_offset = DateOffsetStrategy.model_validate(date_offset, strict=False)
+    if isinstance(custom_era, dict):
+        custom_era = CustomEraStrategy.model_validate(custom_era, strict=False)
+
+    return date_offset, custom_era
+
+
+def collapse_events(events: ir.Table, settings: CollapseSettings | None) -> ir.Table:
+    if not settings or settings.collapse_type != CollapseType.ERA:
+        return events
+    pad_interval = ibis.interval(days=int(settings.era_pad or 0))
+    order_by = [events.start_date, events.end_date, events.event_id]
+    prev_window = ibis.window(
+        group_by=events.person_id,
+        order_by=order_by,
+        preceding=(None, 1),
+    )
+    extended_end = events.end_date + cast(Any, pad_interval)
+    prev_max = extended_end.max().over(prev_window)
+    is_start = ibis.ifelse(
+        prev_max.notnull() & (prev_max >= events.start_date),
+        0,
+        1,
+    )
+    annotated = events.mutate(
+        extended_end=extended_end,
+        is_start=is_start,
+    )
+    is_start_col = cast(ir.IntegerColumn, annotated["is_start"])
+    era_window = ibis.window(
+        group_by=annotated.person_id,
+        order_by=[
+            annotated.start_date,
+            ibis.desc(is_start_col),
+            annotated.end_date,
+            annotated.event_id,
+        ],
+    )
+    era_id = is_start_col.cumsum().over(era_window)
+    grouped = annotated.mutate(_era_id=era_id)
+    max_end = cast(ir.IntervalScalar, grouped.extended_end.max())
+    collapsed = grouped.group_by(grouped.person_id, grouped._era_id).aggregate(
+        start_date=grouped.start_date.min(),
+        end_date=(max_end - pad_interval),
+        visit_occurrence_id=grouped.visit_occurrence_id.max(),
+    )
+    final_window = ibis.window(
+        order_by=[collapsed.person_id, collapsed.start_date, collapsed.end_date]
+    )
+    collapsed = collapsed.mutate(
+        event_id=(ibis.row_number().over(final_window) + 1)
+    ).select("person_id", "event_id", "start_date", "end_date", "visit_occurrence_id")
+    return collapsed
+
+
+def _apply_custom_era_strategy(
+    events: ir.Table, strategy: CustomEraStrategy, ctx: BuildContext
+) -> ir.Table:
+    if strategy.drug_codeset_id is None:
+        raise ValueError("Custom era strategy requires a drug codeset id.")
+
+    persons = events.select(events.person_id).distinct()
+    codeset = ctx.codesets.filter(ctx.codesets.codeset_id == strategy.drug_codeset_id)
+    drug_exposure = ctx.table("drug_exposure")
+
+    def _exposure_query(concept_column: str) -> ir.Table:
+        return (
+            drug_exposure.join(persons, ["person_id"])
+            .join(codeset, drug_exposure[concept_column] == codeset.concept_id)
+            .select(
+                drug_exposure.person_id,
+                drug_exposure.drug_exposure_start_date.name("drug_exposure_start_date"),
+                _drug_exposure_end(drug_exposure, strategy).name(
+                    "drug_exposure_end_date"
+                ),
+            )
+        )
+
+    exposures = _exposure_query("drug_concept_id").union(
+        _exposure_query("drug_source_concept_id"), distinct=False
+    )
+
+    gap = int(strategy.gap_days or 0)
+    offset = int(strategy.offset or 0)
+    extend_interval = ibis.interval(days=gap + offset)
+
+    dt = exposures.select(
+        exposures.person_id,
+        exposures.drug_exposure_start_date.name("start_date"),
+        (exposures.drug_exposure_end_date + extend_interval).name("extended_end"),
+    ).distinct()
+
+    prev_max_window = ibis.window(
+        group_by=dt.person_id,
+        order_by=[dt.start_date, dt.extended_end],
+        preceding=(None, 1),
+    )
+    prev_running_max = dt.extended_end.max().over(prev_max_window)
+    is_start = ibis.ifelse(
+        prev_running_max.notnull() & (prev_running_max >= dt.start_date), 0, 1
+    )
+    staged = dt.mutate(is_start=is_start).view()
+    cumsum_window = ibis.window(
+        group_by=staged.person_id, order_by=[staged.start_date, staged.extended_end]
+    )
+    group_idx = staged.is_start.cumsum().over(cumsum_window)
+    annotated = staged.mutate(group_idx=group_idx)
+
+    eras = annotated.group_by(annotated.person_id, annotated.group_idx).aggregate(
+        era_start=annotated.start_date.min(),
+        era_end=(annotated.extended_end.max() - ibis.interval(days=gap)),
+    )
+
+    join_condition = (
+        (events.person_id == eras.person_id)
+        & (events.start_date >= eras.era_start)
+        & (events.start_date <= eras.era_end)
+    )
+    joined = events.join(eras, join_condition, how="inner")
+    if not joined.columns:
+        return events.limit(0)
+    supplemental = [
+        joined[column]
+        for column in ("observation_period_start_date", "observation_period_end_date")
+        if column in joined.columns
+    ]
+    return joined.select(
+        joined.person_id,
+        joined.event_id,
+        joined.start_date,
+        joined.era_end.name("end_date"),
+        joined.visit_occurrence_id,
+        *supplemental,
+    )
+
+
+def _drug_exposure_end(
+    drug_exposure: ir.Table, strategy: CustomEraStrategy
+) -> ir.Value:
+    start = drug_exposure.drug_exposure_start_date
+    if strategy.days_supply_override is not None:
+        return start + ibis.interval(days=int(strategy.days_supply_override))
+
+    end_candidates = [
+        drug_exposure.drug_exposure_end_date,
+        ibis.ifelse(
+            drug_exposure.days_supply.notnull(),
+            start + (ibis.interval(days=1) * drug_exposure.days_supply.cast("int64")),
+            ibis.null(),
+        ),
+        start + ibis.interval(days=1),
+    ]
+    return ibis.coalesce(*end_candidates)

--- a/circe/execution/builders/condition_era.py
+++ b/circe/execution/builders/condition_era.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import ConditionEra
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_interval_range,
+    apply_numeric_range,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("ConditionEra")
+def build_condition_era(criteria: ConditionEra, ctx: BuildContext):
+    table = ctx.table("condition_era")
+
+    table = apply_codeset_filter(
+        table, "condition_concept_id", criteria.codeset_id, ctx
+    )
+    table = apply_date_range(table, "condition_era_start_date", criteria.era_start_date)
+    table = apply_date_range(table, "condition_era_end_date", criteria.era_end_date)
+    table = apply_numeric_range(
+        table, "condition_occurrence_count", criteria.occurrence_count
+    )
+    table = apply_interval_range(
+        table, "condition_era_start_date", "condition_era_end_date", criteria.era_length
+    )
+
+    if criteria.age_at_start:
+        table = apply_age_filter(
+            table, criteria.age_at_start, ctx, "condition_era_start_date"
+        )
+    if criteria.age_at_end:
+        table = apply_age_filter(
+            table, criteria.age_at_end, ctx, "condition_era_end_date"
+        )
+
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    if criteria.first:
+        table = apply_first_event(table, "condition_era_start_date", "condition_era_id")
+
+    events = standardize_output(
+        table,
+        primary_key="condition_era_id",
+        start_column="condition_era_start_date",
+        end_column="condition_era_end_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/condition_occurrence.py
+++ b/circe/execution/builders/condition_occurrence.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import ConditionOccurrence
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_visit_concept_filters,
+    coerce_concept_set_selection,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("ConditionOccurrence")
+def build_condition_occurrence(criteria: ConditionOccurrence, ctx: BuildContext):
+    table = ctx.table("condition_occurrence")
+
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="condition_type_concept_id",
+        concepts=criteria.condition_type,
+        selection=criteria.condition_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.condition_type_exclude),
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="condition_status_concept_id",
+        concepts=getattr(criteria, "condition_status", None),
+        selection=None,
+        ctx=ctx,
+    )
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    source_filter = getattr(criteria, "condition_source_concept", None)
+    selection = coerce_concept_set_selection(source_filter)
+    if selection is not None:
+        table = apply_concept_criteria(
+            table,
+            column="condition_source_concept_id",
+            concepts=None,
+            selection=selection,
+            ctx=ctx,
+        )
+
+    visit_source = getattr(criteria, "visit_source_concept", None)
+    needs_visit_filters = bool(
+        criteria.visit_type or criteria.visit_type_cs or visit_source is not None
+    )
+    if needs_visit_filters:
+        visit = ctx.table("visit_occurrence").select(
+            "person_id",
+            "visit_occurrence_id",
+            "visit_concept_id",
+            "visit_source_concept_id",
+        )
+        table = table.join(
+            visit,
+            (table.visit_occurrence_id == visit.visit_occurrence_id)
+            & (table.person_id == visit.person_id),
+        )
+        table = apply_visit_concept_filters(
+            table, criteria.visit_type, criteria.visit_type_cs, ctx
+        )
+        if visit_source is not None:
+            table = table.filter(table.visit_source_concept_id == int(visit_source))
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/death.py
+++ b/circe/execution/builders/death.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import ibis
+
+from ...cohortdefinition.criteria import Death
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_gender_filter,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("Death")
+def build_death(criteria: Death, ctx: BuildContext):
+    table = ctx.table("death")
+
+    table = apply_codeset_filter(table, "cause_concept_id", criteria.codeset_id, ctx)
+
+    table = apply_date_range(
+        table, "death_date", getattr(criteria, "occurrence_start_date", None)
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="death_type_concept_id",
+        concepts=criteria.death_type,
+        selection=criteria.death_type_cs,
+        ctx=ctx,
+        exclude=bool(getattr(criteria, "death_type_exclude", False)),
+    )
+
+    if getattr(criteria, "death_source_concept", None) is not None:
+        table = apply_codeset_filter(
+            table,
+            "cause_source_concept_id",
+            int(criteria.death_source_concept),
+            ctx,
+        )
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    window = ibis.window(order_by=[table.person_id, table.death_date])
+    table = table.mutate(death_event_id=ibis.row_number().over(window))
+
+    events = standardize_output(
+        table,
+        primary_key="death_event_id",
+        start_column="death_date",
+        end_column="death_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/device_exposure.py
+++ b/circe/execution/builders/device_exposure.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import DeviceExposure
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    apply_text_filter,
+    apply_visit_concept_filters,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("DeviceExposure")
+def build_device_exposure(criteria: DeviceExposure, ctx: BuildContext):
+    table = ctx.table("device_exposure")
+
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="device_type_concept_id",
+        concepts=criteria.device_type,
+        selection=criteria.device_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.device_type_exclude),
+    )
+
+    table = apply_numeric_range(table, "quantity", criteria.quantity)
+    table = apply_text_filter(
+        table, "unique_device_id", getattr(criteria, "unique_device_id", None)
+    )
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        getattr(criteria, "provider_specialty", None),
+        getattr(criteria, "provider_specialty_cs", None),
+        ctx,
+        provider_column="provider_id",
+    )
+    table = apply_visit_concept_filters(
+        table, criteria.visit_type, criteria.visit_type_cs, ctx
+    )
+    if criteria.device_source_concept is not None:
+        table = apply_codeset_filter(
+            table,
+            "device_source_concept_id",
+            criteria.device_source_concept,
+            ctx,
+        )
+
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/dose_era.py
+++ b/circe/execution/builders/dose_era.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import DoseEra
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_interval_range,
+    apply_numeric_range,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("DoseEra")
+def build_dose_era(criteria: DoseEra, ctx: BuildContext):
+    table = ctx.table("dose_era")
+
+    table = apply_codeset_filter(table, "drug_concept_id", criteria.codeset_id, ctx)
+    table = apply_date_range(table, "dose_era_start_date", criteria.era_start_date)
+    table = apply_date_range(table, "dose_era_end_date", criteria.era_end_date)
+
+    table = apply_concept_criteria(
+        table,
+        column="unit_concept_id",
+        concepts=criteria.unit,
+        selection=criteria.unit_cs,
+        ctx=ctx,
+    )
+
+    table = apply_numeric_range(table, "dose_value", criteria.dose_value)
+    table = apply_interval_range(
+        table, "dose_era_start_date", "dose_era_end_date", criteria.era_length
+    )
+
+    if criteria.age_at_start:
+        table = apply_age_filter(
+            table, criteria.age_at_start, ctx, "dose_era_start_date"
+        )
+    if criteria.age_at_end:
+        table = apply_age_filter(table, criteria.age_at_end, ctx, "dose_era_end_date")
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    if criteria.first:
+        table = apply_first_event(table, "dose_era_start_date", "dose_era_id")
+
+    events = standardize_output(
+        table,
+        primary_key="dose_era_id",
+        start_column="dose_era_start_date",
+        end_column="dose_era_end_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/drug_era.py
+++ b/circe/execution/builders/drug_era.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import DrugEra
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_interval_range,
+    apply_numeric_range,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("DrugEra")
+def build_drug_era(criteria: DrugEra, ctx: BuildContext):
+    table = ctx.table("drug_era")
+
+    table = apply_codeset_filter(table, "drug_concept_id", criteria.codeset_id, ctx)
+    table = apply_date_range(table, "drug_era_start_date", criteria.era_start_date)
+    table = apply_date_range(table, "drug_era_end_date", criteria.era_end_date)
+    table = apply_numeric_range(table, "drug_exposure_count", criteria.occurrence_count)
+    table = apply_numeric_range(table, "gap_days", criteria.gap_days)
+    table = apply_interval_range(
+        table, "drug_era_start_date", "drug_era_end_date", criteria.era_length
+    )
+
+    if criteria.age_at_start:
+        table = apply_age_filter(
+            table, criteria.age_at_start, ctx, "drug_era_start_date"
+        )
+    if criteria.age_at_end:
+        table = apply_age_filter(table, criteria.age_at_end, ctx, "drug_era_end_date")
+
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    if criteria.first:
+        table = apply_first_event(table, "drug_era_start_date", "drug_era_id")
+
+    events = standardize_output(
+        table,
+        primary_key="drug_era_id",
+        start_column="drug_era_start_date",
+        end_column="drug_era_end_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/drug_exposure.py
+++ b/circe/execution/builders/drug_exposure.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import DrugExposure
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    apply_text_filter,
+    apply_visit_concept_filters,
+    coerce_concept_set_selection,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("DrugExposure")
+def build_drug_exposure(criteria: DrugExposure, ctx: BuildContext):
+    table = ctx.table("drug_exposure")
+
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="drug_type_concept_id",
+        concepts=criteria.drug_type,
+        selection=criteria.drug_type_cs,
+        ctx=ctx,
+        exclude=bool(getattr(criteria, "drug_type_exclude", False)),
+    )
+    table = apply_concept_criteria(
+        table,
+        column="route_concept_id",
+        concepts=criteria.route_concept,
+        selection=criteria.route_concept_cs,
+        ctx=ctx,
+    )
+    table = apply_concept_criteria(
+        table,
+        column="dose_unit_concept_id",
+        concepts=getattr(criteria, "dose_unit", []),
+        selection=getattr(criteria, "dose_unit_cs", None),
+        ctx=ctx,
+    )
+
+    table = apply_numeric_range(table, "quantity", criteria.quantity)
+    table = apply_numeric_range(table, "days_supply", criteria.days_supply)
+    table = apply_numeric_range(table, "refills", criteria.refills)
+    table = apply_text_filter(
+        table, "stop_reason", getattr(criteria, "stop_reason", None)
+    )
+    table = apply_text_filter(
+        table, "lot_number", getattr(criteria, "lot_number", None)
+    )
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        getattr(criteria, "provider_specialty", None),
+        getattr(criteria, "provider_specialty_cs", None),
+        ctx,
+        provider_column="provider_id",
+    )
+    table = apply_visit_concept_filters(
+        table, criteria.visit_type, criteria.visit_type_cs, ctx
+    )
+
+    source_filter = getattr(criteria, "drug_source_concept", None)
+    selection = coerce_concept_set_selection(source_filter)
+    if selection is not None:
+        table = apply_concept_criteria(
+            table,
+            column="drug_source_concept_id",
+            concepts=None,
+            selection=selection,
+            ctx=ctx,
+        )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/groups.py
+++ b/circe/execution/builders/groups.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import ibis
+import ibis.common.exceptions as ibis_exc
+import ibis.expr.types as ir
+
+from ...cohortdefinition.core import ObservationFilter
+from ...cohortdefinition.criteria import (
+    Criteria,
+    CriteriaColumn,
+    CriteriaGroup,
+    VisitDetail,
+)
+from ..build_context import BuildContext
+from ..criteria_compat import (
+    CorrelatedCriteria,
+    DemoGraphicCriteria,
+    OccurrenceType,
+    parse_single_criteria,
+)
+from .common import (
+    apply_age_filter,
+    apply_date_range,
+    apply_ethnicity_filter,
+    apply_gender_filter,
+    apply_observation_window,
+    apply_race_filter,
+)
+from .registry import build_events
+
+
+def apply_criteria_group(
+    events: ir.Table, group: CriteriaGroup | None, ctx: BuildContext
+) -> ir.Table:
+    mask = _group_mask(events, group, ctx)
+    if mask is None:
+        return events
+    return events.filter(mask)
+
+
+def _correlated_mask(
+    events: ir.Table, correlated: CorrelatedCriteria, ctx: BuildContext
+) -> ir.Value:
+    criteria_model = correlated.criteria
+    if criteria_model and not isinstance(criteria_model, ir.Expr):
+        criteria_model = parse_single_criteria(criteria_model)
+    if criteria_model is None:
+        return ibis.literal(True)
+
+    count_column_name, count_column_enum = _resolve_count_column(correlated.occurrence)
+
+    base_events = build_events(criteria_model, ctx)
+    base_events = _attach_count_columns(
+        base_events,
+        criteria_model,
+        ctx,
+        count_column_name=count_column_name,
+        count_column_enum=count_column_enum,
+    )
+    requires_corr_end_alignment = _requires_observation_period_end_alignment(correlated)
+    zero_window: ObservationFilter | None = None
+    if not correlated.ignore_observation_period:
+        zero_window = ObservationFilter(prior_days=0, post_days=0)
+        base_events = apply_observation_window(base_events, zero_window, ctx)
+
+    index_events = events
+    if not correlated.ignore_observation_period:
+        missing_observation_bounds = (
+            "observation_period_start_date" not in index_events.columns
+            or "observation_period_end_date" not in index_events.columns
+        )
+        if missing_observation_bounds:
+            zero_window = zero_window or ObservationFilter(prior_days=0, post_days=0)
+            index_events = apply_observation_window(index_events, zero_window, ctx)
+
+    select_fields = [
+        base_events.person_id,
+        base_events.event_id.name("_corr_event_id"),
+        base_events.start_date.name("_corr_start_date"),
+        base_events.end_date.name("_corr_end_date"),
+    ]
+    if "visit_occurrence_id" in base_events.columns:
+        select_fields.append(
+            base_events.visit_occurrence_id.name("_corr_visit_occurrence_id")
+        )
+    if count_column_name and count_column_name in base_events.columns:
+        select_fields.append(base_events[count_column_name])
+
+    criteria_events = base_events.select(*select_fields)
+    join_condition = index_events.person_id == criteria_events.person_id
+    if not correlated.ignore_observation_period:
+        if "observation_period_start_date" in index_events.columns:
+            join_condition &= (
+                criteria_events._corr_start_date
+                >= index_events.observation_period_start_date
+            )
+        if "observation_period_end_date" in index_events.columns:
+            join_condition &= (
+                criteria_events._corr_start_date
+                <= index_events.observation_period_end_date
+            )
+            if requires_corr_end_alignment:
+                join_condition &= (
+                    criteria_events._corr_end_date
+                    <= index_events.observation_period_end_date
+                )
+    window_condition = _build_window_condition(
+        index_events, criteria_events, correlated
+    )
+    if window_condition is not None:
+        join_condition &= window_condition
+
+    occurrence = correlated.occurrence
+    occ_type = getattr(occurrence, "type", None)
+    if isinstance(occ_type, int):
+        occ_type = OccurrenceType(occurrence.type)
+
+    require_same_visit = bool(correlated.restrict_visit)
+    if correlated.restrict_visit is None and isinstance(criteria_model, VisitDetail):
+        require_same_visit = True
+
+    if require_same_visit:
+        if (
+            "visit_occurrence_id" in index_events.columns
+            and "_corr_visit_occurrence_id" in criteria_events.columns
+        ):
+            join_condition &= (
+                index_events.visit_occurrence_id.notnull()
+                & criteria_events._corr_visit_occurrence_id.notnull()
+                & (
+                    index_events.visit_occurrence_id
+                    == criteria_events._corr_visit_occurrence_id
+                )
+            )
+
+    joined = index_events.join(criteria_events, join_condition, how="left")
+
+    corr_event_id = joined._corr_event_id
+    count_expr = corr_event_id
+    if count_column_name and count_column_name in joined.columns:
+        count_expr = joined[count_column_name]
+    match_expr = corr_event_id.notnull()
+    joined = joined.mutate(
+        _corr_match_value=ibis.ifelse(match_expr, count_expr, ibis.null()),
+    )
+
+    if correlated.occurrence and correlated.occurrence.is_distinct:
+        aggregator = joined._corr_match_value.nunique()
+    else:
+        aggregator = joined._corr_match_value.count()
+
+    aggregated = joined.group_by(joined.person_id, joined.event_id).aggregate(
+        match_count=aggregator
+    )
+    predicate = _occurrence_predicate(aggregated.match_count, correlated.occurrence)
+    matching_ids = (
+        aggregated.filter(predicate).select("person_id", "event_id").distinct()
+    )
+    return _event_membership_mask(events, matching_ids)
+
+
+def _group_mask(
+    events: ir.Table, group: CriteriaGroup | None, ctx: BuildContext
+) -> ir.Value | None:
+    if not group or group.is_empty():
+        return None
+
+    masks: list[ir.Value] = []
+    for correlated in group.criteria_list or []:
+        masks.append(_correlated_mask(events, correlated, ctx))
+
+    for demographic in group.demographic_criteria_list or []:
+        demo_mask = _demographic_mask(events, demographic, ctx)
+        if demo_mask is not None:
+            masks.append(demo_mask)
+
+    for subgroup in group.groups or []:
+        sub_mask = _group_mask(events, subgroup, ctx)
+        if sub_mask is not None:
+            masks.append(sub_mask)
+
+    if not masks:
+        return None
+
+    group_type = (group.type or "ALL").upper()
+    if group_type == "ANY":
+        return _combine_any(masks)
+    if group_type.startswith("AT_"):
+        count = group.count
+        if group_type.endswith("LEAST"):
+            threshold = count if count is not None else 1
+            return _combine_threshold(masks, threshold, at_least=True)
+        threshold = count if count is not None else 0
+        return _combine_threshold(masks, threshold, at_least=False)
+    return _combine_all(masks)
+
+
+def _combine_all(masks: list[ir.Value]) -> ir.Value:
+    combined = masks[0]
+    for mask in masks[1:]:
+        combined = combined & mask
+    return combined
+
+
+def _combine_any(masks: list[ir.Value]) -> ir.Value:
+    combined = masks[0]
+    for mask in masks[1:]:
+        combined = combined | mask
+    return combined
+
+
+def _combine_threshold(
+    masks: list[ir.Value], threshold: int, *, at_least: bool
+) -> ir.Value:
+    def _to_int(mask: ir.Value) -> ir.Value:
+        return ibis.ifelse(
+            mask, ibis.literal(1, type="int64"), ibis.literal(0, type="int64")
+        )
+
+    total = _to_int(masks[0])
+    for mask in masks[1:]:
+        total = total + _to_int(mask)
+    return total >= threshold if at_least else total <= threshold
+
+
+def _demographic_mask(
+    events: ir.Table, demographic: DemoGraphicCriteria, ctx: BuildContext
+) -> ir.Value | None:
+    if demographic is None:
+        return None
+
+    filtered = events
+    applied = False
+    if demographic.age:
+        filtered = apply_age_filter(filtered, demographic.age, ctx, "start_date")
+        applied = True
+    if demographic.gender or demographic.gender_cs:
+        filtered = apply_gender_filter(
+            filtered, demographic.gender, demographic.gender_cs, ctx
+        )
+        applied = True
+    if demographic.race or demographic.race_cs:
+        filtered = apply_race_filter(
+            filtered, demographic.race, demographic.race_cs, ctx
+        )
+        applied = True
+    if demographic.ethnicity or demographic.ethnicity_cs:
+        filtered = apply_ethnicity_filter(
+            filtered, demographic.ethnicity, demographic.ethnicity_cs, ctx
+        )
+        applied = True
+    if demographic.occurrence_start_date:
+        filtered = apply_date_range(
+            filtered, "start_date", demographic.occurrence_start_date
+        )
+        applied = True
+    if demographic.occurrence_end_date:
+        filtered = apply_date_range(
+            filtered, "end_date", demographic.occurrence_end_date
+        )
+        applied = True
+
+    if not applied:
+        return None
+
+    filtered_ids = filtered.select(filtered.person_id, filtered.event_id).distinct()
+    return _event_membership_mask(events, filtered_ids)
+
+
+def _event_membership_mask(events: ir.Table, ids: ir.Table) -> ir.Value:
+    keys = ids.mutate(_event_key=_event_key_expr(ids)).select("_event_key")
+    return _event_key_expr(events).isin(keys._event_key)
+
+
+def _event_key_expr(table: ir.Table) -> ir.Value:
+    return (
+        table.person_id.cast("string")
+        + ibis.literal(":")
+        + table.event_id.cast("string")
+    )
+
+
+def _occurrence_predicate(count_expr: ir.Value, occurrence) -> ir.Value:
+    if occurrence is None:
+        return count_expr > 0
+
+    occ_type = occurrence.type
+    if isinstance(occ_type, int):
+        occ_type = OccurrenceType(occurrence.type)
+
+    if occ_type == OccurrenceType.EXACTLY:
+        return count_expr == occurrence.count
+    if occ_type == OccurrenceType.AT_LEAST:
+        return count_expr >= occurrence.count
+    if occ_type == OccurrenceType.AT_MOST:
+        return count_expr <= occurrence.count
+    return count_expr > 0
+
+
+def _build_window_condition(
+    index_events: ir.Table, correlated_events: ir.Table, correlated: CorrelatedCriteria
+) -> ir.Value:
+    cond = ibis.literal(True)
+
+    if correlated.start_window:
+        correlated_start = _correlated_window_value(
+            correlated_events,
+            correlated.start_window.use_event_end,
+            default="start",
+        )
+        lower = _apply_endpoint_anchor(
+            index_events,
+            correlated.start_window.start,
+            correlated.start_window.use_index_end,
+        )
+        upper = _apply_endpoint_anchor(
+            index_events,
+            correlated.start_window.end,
+            correlated.start_window.use_index_end,
+        )
+        if lower is not None:
+            cond &= correlated_start >= lower
+        if upper is not None:
+            cond &= correlated_start <= upper
+
+    if correlated.end_window:
+        lower = _apply_endpoint_anchor(
+            index_events,
+            correlated.end_window.start,
+            correlated.end_window.use_index_end,
+            default_to_index_end=False,
+        )
+        upper = _apply_endpoint_anchor(
+            index_events,
+            correlated.end_window.end,
+            correlated.end_window.use_index_end,
+            default_to_index_end=False,
+        )
+        correlated_end = _correlated_window_value(
+            correlated_events,
+            correlated.end_window.use_event_end,
+            default="end",
+        )
+        if lower is not None:
+            cond &= correlated_end >= lower
+        if upper is not None:
+            cond &= correlated_end <= upper
+
+    return cond
+
+
+def _apply_endpoint_anchor(
+    events: ir.Table,
+    endpoint,
+    use_index_end: bool | None,
+    *,
+    default_to_index_end: bool = False,
+):
+    anchor = (
+        events.end_date
+        if (use_index_end or (use_index_end is None and default_to_index_end))
+        else events.start_date
+    )
+    if not endpoint or endpoint.days is None:
+        return None
+    days = ibis.interval(days=int(endpoint.days))
+    coeff = endpoint.coeff if endpoint.coeff is not None else 1
+    return anchor + days * coeff
+
+
+def _correlated_window_value(
+    correlated_events: ir.Table,
+    use_event_end: bool | None,
+    *,
+    default: str,
+) -> ir.Value:
+    if use_event_end is True:
+        return correlated_events._corr_end_date
+    if use_event_end is False:
+        return correlated_events._corr_start_date
+    if default == "end":
+        return correlated_events._corr_end_date
+    return correlated_events._corr_start_date
+
+
+_COUNT_COLUMN_MAPPING: dict[CriteriaColumn, str] = {
+    CriteriaColumn.START_DATE: "_corr_start_date",
+    CriteriaColumn.END_DATE: "_corr_end_date",
+    CriteriaColumn.VISIT_ID: "_corr_visit_occurrence_id",
+    CriteriaColumn.DOMAIN_CONCEPT: "_corr_domain_concept_id",
+    CriteriaColumn.DOMAIN_SOURCE_CONCEPT: "_corr_domain_source_concept_id",
+}
+
+
+_COUNT_COLUMN_SOURCES: dict[CriteriaColumn, Callable[[Criteria], str]] = {
+    CriteriaColumn.DOMAIN_CONCEPT: lambda criteria: criteria.get_concept_id_column(),
+    CriteriaColumn.DOMAIN_SOURCE_CONCEPT: lambda criteria: _source_concept_column(
+        criteria
+    ),
+}
+
+
+def _resolve_count_column(occurrence):
+    if occurrence is None or occurrence.count_column is None:
+        return None, None
+    column = occurrence.count_column
+    enum_value: CriteriaColumn | None = None
+    if isinstance(column, CriteriaColumn):
+        enum_value = column
+    else:
+        value = str(column)
+        if value.upper() in CriteriaColumn.__members__:
+            enum_value = CriteriaColumn[value.upper()]
+        else:
+            lower = value.lower()
+            for member in CriteriaColumn:
+                if member.value == lower:
+                    enum_value = member
+                    break
+    if enum_value is None:
+        return None, None
+    return _COUNT_COLUMN_MAPPING.get(enum_value), enum_value
+
+
+def _source_concept_column(criteria) -> str:
+    prefix = criteria.snake_case_class_name().split("_")[0]
+    return f"{prefix}_source_concept_id"
+
+
+def _attach_count_columns(
+    events: ir.Table,
+    criteria_model,
+    ctx: BuildContext,
+    *,
+    count_column_name: str | None,
+    count_column_enum: CriteriaColumn | None,
+) -> ir.Table:
+    if not count_column_name or not count_column_enum:
+        return events
+    source_getter = _COUNT_COLUMN_SOURCES.get(count_column_enum)
+    if source_getter is None:
+        return events
+    source_column = source_getter(criteria_model)
+    if source_column is None:
+        return events
+    table_name = criteria_model.snake_case_class_name()
+    try:
+        domain_table = ctx.table(table_name)
+    except (
+        ibis_exc.IbisError,
+        TypeError,
+        ValueError,
+        AttributeError,
+        NotImplementedError,
+    ):
+        return events
+    if source_column not in domain_table.columns:
+        return events
+    primary_key = criteria_model.get_primary_key_column()
+    if primary_key not in domain_table.columns:
+        return events
+    lookup = domain_table.select(
+        domain_table[primary_key].name("_corr_join_key"),
+        domain_table[source_column].name(count_column_name),
+    )
+    augmented = events.join(
+        lookup, events.event_id == lookup._corr_join_key, how="left"
+    )
+    base_columns = events.columns
+    projection = [augmented[name] for name in base_columns if name in augmented.columns]
+    projection.append(augmented[count_column_name])
+    return augmented.select(*projection)
+
+
+def _requires_observation_period_end_alignment(correlated: CorrelatedCriteria) -> bool:
+    if correlated.start_window and correlated.start_window.use_event_end:
+        return True
+    if correlated.end_window and correlated.end_window.use_event_end:
+        return True
+    occurrence = correlated.occurrence
+    if occurrence and occurrence.count_column is not None:
+        resolved, _ = _resolve_count_column(occurrence)
+        return resolved == "_corr_end_date"
+    return False

--- a/circe/execution/builders/measurement.py
+++ b/circe/execution/builders/measurement.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import ibis
+
+from ...cohortdefinition.criteria import Measurement
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    apply_visit_concept_filters,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("Measurement")
+def build_measurement(criteria: Measurement, ctx: BuildContext):
+    table = ctx.table("measurement")
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="measurement_type_concept_id",
+        concepts=criteria.measurement_type,
+        selection=criteria.measurement_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.measurement_type_exclude),
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="operator_concept_id",
+        concepts=getattr(criteria, "operator_concept", None),
+        selection=getattr(criteria, "operator_concept_cs", None),
+        ctx=ctx,
+    )
+
+    value_column = "value_as_number"
+    if criteria.unit:
+        table = apply_concept_criteria(
+            table,
+            column="unit_concept_id",
+            concepts=criteria.unit,
+            selection=None,
+            ctx=ctx,
+        )
+        table, value_column = _maybe_normalize_units(
+            table, criteria.unit, criteria.value_as_number
+        )
+    table = apply_concept_criteria(
+        table,
+        column="unit_concept_id",
+        concepts=None,
+        selection=criteria.unit_cs,
+        ctx=ctx,
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="value_as_concept_id",
+        concepts=criteria.value_as_concept,
+        selection=criteria.value_as_concept_cs,
+        ctx=ctx,
+    )
+
+    table = apply_numeric_range(table, value_column, criteria.value_as_number)
+    table = apply_numeric_range(table, "range_low", criteria.range_low)
+    table = apply_numeric_range(table, "range_high", criteria.range_high)
+    if getattr(criteria, "range_low_ratio", None):
+        denom = ibis.ifelse(table.range_low == 0, ibis.null(), table.range_low)
+        ratio = (table.value_as_number / denom).name("_range_low_ratio")
+        table = table.mutate(_range_low_ratio=ratio)
+        table = apply_numeric_range(table, "_range_low_ratio", criteria.range_low_ratio)
+    if getattr(criteria, "range_high_ratio", None):
+        denom = ibis.ifelse(table.range_high == 0, ibis.null(), table.range_high)
+        ratio = (table.value_as_number / denom).name("_range_high_ratio")
+        table = table.mutate(_range_high_ratio=ratio)
+        table = apply_numeric_range(
+            table, "_range_high_ratio", criteria.range_high_ratio
+        )
+
+    if getattr(criteria, "abnormal", None):
+        abnormal_predicate = (
+            (table.value_as_number < table.range_low)
+            | (table.value_as_number > table.range_high)
+            | table.value_as_concept_id.isin([4155142, 4155143])
+        )
+        table = table.filter(abnormal_predicate)
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        getattr(criteria, "provider_specialty", None),
+        getattr(criteria, "provider_specialty_cs", None),
+        ctx,
+        provider_column="provider_id",
+    )
+    table = apply_visit_concept_filters(
+        table, criteria.visit_type, criteria.visit_type_cs, ctx
+    )
+    if criteria.measurement_source_concept is not None:
+        table = apply_codeset_filter(
+            table,
+            "measurement_source_concept_id",
+            criteria.measurement_source_concept,
+            ctx,
+        )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)
+
+
+def _maybe_normalize_units(table, units, value_range):
+    """
+    Best-effort unit normalization for numeric comparisons.
+
+    Circe generally relies on unit-specific criteria rows (separate thresholds per unit scale).
+    Normalizing in that situation breaks parity (e.g. neutrophil counts expressed as 10..1500 cells/uL).
+
+    Strategy:
+      - Always normalize mass to kilograms (pounds -> kg).
+      - For cell counts, only normalize when the numeric range appears to be in the canonical 10^9/L scale.
+        Heuristic: upper bound <= 100.
+    """
+    unit_ids = [
+        concept.concept_id for concept in units if concept.concept_id is not None
+    ]
+    if not unit_ids:
+        return table, "value_as_number"
+    if not all(unit_id in _UNIT_NORMALIZATION for unit_id in unit_ids):
+        return table, "value_as_number"
+    groups = {_UNIT_NORMALIZATION[unit_id][0] for unit_id in unit_ids}
+    if len(groups) != 1:
+        return table, "value_as_number"
+
+    group = next(iter(groups))
+    if group == "mass_kg":
+        should_normalize = True
+    elif group == "count_10e9_per_l":
+        should_normalize = _range_looks_like_canonical_cell_count(value_range)
+    else:
+        should_normalize = False
+
+    if not should_normalize:
+        return table, "value_as_number"
+
+    multiplier = _unit_multiplier_expr(table.unit_concept_id, unit_ids)
+    normalized = (table.value_as_number * multiplier).name("_normalized_value")
+    table = table.mutate(_normalized_value=normalized)
+    return table, "_normalized_value"
+
+
+def _range_looks_like_canonical_cell_count(value_range) -> bool:
+    if value_range is None or value_range.value is None:
+        return False
+    op = (value_range.op or "eq").lower()
+    upper = float(value_range.value)
+    if op.endswith("bt") and value_range.extent is not None:
+        upper = max(upper, float(value_range.extent))
+    # Canonical 10^9/L scale is typically << 100; high thresholds indicate raw unit ranges.
+    return upper <= 100.0
+
+
+def _unit_multiplier_expr(unit_column, unit_ids):
+    multiplier_expr = ibis.literal(1.0)
+    for unit_id in unit_ids:
+        multiplier = _UNIT_NORMALIZATION[unit_id][1]
+        multiplier_expr = ibis.ifelse(
+            unit_column == ibis.literal(unit_id),
+            ibis.literal(multiplier),
+            multiplier_expr,
+        )
+    return multiplier_expr
+
+
+_UNIT_NORMALIZATION = {
+    # Mass
+    9529: ("mass_kg", 1.0),  # kilogram
+    3195625: ("mass_kg", 0.45359237),  # pound
+    # Cell counts per liter (expressed in 10^9/L)
+    9444: ("count_10e9_per_l", 1.0),  # billion per liter
+    44777588: ("count_10e9_per_l", 1.0),
+    8848: ("count_10e9_per_l", 1.0),  # thousand per microliter
+    8816: ("count_10e9_per_l", 1.0),  # million per milliliter
+    8961: ("count_10e9_per_l", 1.0),  # thousand per cubic millimeter
+    8784: ("count_10e9_per_l", 0.001),  # cells per microliter
+    8647: ("count_10e9_per_l", 0.001),  # per microliter
+}

--- a/circe/execution/builders/observation.py
+++ b/circe/execution/builders/observation.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import Observation
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    apply_text_filter,
+    apply_visit_concept_filters,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("Observation")
+def build_observation(criteria: Observation, ctx: BuildContext):
+    table = ctx.table("observation")
+    table = apply_codeset_filter(
+        table, criteria.get_concept_id_column(), criteria.codeset_id, ctx
+    )
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="observation_type_concept_id",
+        concepts=criteria.observation_type,
+        selection=criteria.observation_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.observation_type_exclude),
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="qualifier_concept_id",
+        concepts=criteria.qualifier,
+        selection=criteria.qualifier_cs,
+        ctx=ctx,
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="unit_concept_id",
+        concepts=criteria.unit,
+        selection=criteria.unit_cs,
+        ctx=ctx,
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="value_as_concept_id",
+        concepts=criteria.value_as_concept,
+        selection=criteria.value_as_concept_cs,
+        ctx=ctx,
+    )
+
+    table = apply_numeric_range(table, "value_as_number", criteria.value_as_number)
+    table = apply_text_filter(table, "value_as_string", criteria.value_as_string)
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        getattr(criteria, "provider_specialty", None),
+        getattr(criteria, "provider_specialty_cs", None),
+        ctx,
+        provider_column="provider_id",
+    )
+    table = apply_visit_concept_filters(
+        table, criteria.visit_type, criteria.visit_type_cs, ctx
+    )
+    if criteria.observation_source_concept is not None:
+        table = apply_codeset_filter(
+            table,
+            "observation_source_concept_id",
+            criteria.observation_source_concept,
+            ctx,
+        )
+
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/observation_period.py
+++ b/circe/execution/builders/observation_period.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import ObservationPeriod
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_interval_range,
+    apply_user_defined_period,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("ObservationPeriod")
+def build_observation_period(criteria: ObservationPeriod, ctx: BuildContext):
+    table = ctx.table("observation_period")
+
+    table = apply_date_range(
+        table, "observation_period_start_date", criteria.period_start_date
+    )
+    table = apply_date_range(
+        table, "observation_period_end_date", criteria.period_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="period_type_concept_id",
+        concepts=criteria.period_type,
+        selection=criteria.period_type_cs,
+        ctx=ctx,
+    )
+
+    table = apply_interval_range(
+        table,
+        "observation_period_start_date",
+        "observation_period_end_date",
+        criteria.period_length,
+    )
+
+    if criteria.age_at_start:
+        table = apply_age_filter(
+            table, criteria.age_at_start, ctx, "observation_period_start_date"
+        )
+    if criteria.age_at_end:
+        table = apply_age_filter(
+            table, criteria.age_at_end, ctx, "observation_period_end_date"
+        )
+
+    table, start_column, end_column = apply_user_defined_period(
+        table,
+        "observation_period_start_date",
+        "observation_period_end_date",
+        criteria.user_defined_period,
+    )
+
+    if criteria.first:
+        table = apply_first_event(table, start_column, "observation_period_id")
+
+    events = standardize_output(
+        table,
+        primary_key="observation_period_id",
+        start_column=start_column,
+        end_column=end_column,
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/payer_plan_period.py
+++ b/circe/execution/builders/payer_plan_period.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import PayerPlanPeriod
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_interval_range,
+    apply_user_defined_period,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("PayerPlanPeriod")
+def build_payer_plan_period(criteria: PayerPlanPeriod, ctx: BuildContext):
+    table = ctx.table("payer_plan_period")
+
+    table = apply_date_range(
+        table, "payer_plan_period_start_date", criteria.period_start_date
+    )
+    table = apply_date_range(
+        table, "payer_plan_period_end_date", criteria.period_end_date
+    )
+
+    table = apply_interval_range(
+        table,
+        "payer_plan_period_start_date",
+        "payer_plan_period_end_date",
+        criteria.period_length,
+    )
+
+    if criteria.age_at_start:
+        table = apply_age_filter(
+            table, criteria.age_at_start, ctx, "payer_plan_period_start_date"
+        )
+    if criteria.age_at_end:
+        table = apply_age_filter(
+            table, criteria.age_at_end, ctx, "payer_plan_period_end_date"
+        )
+
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    table = apply_codeset_filter(table, "payer_concept_id", criteria.payer_concept, ctx)
+    table = apply_codeset_filter(table, "plan_concept_id", criteria.plan_concept, ctx)
+    table = apply_codeset_filter(
+        table, "sponsor_concept_id", criteria.sponsor_concept, ctx
+    )
+    table = apply_codeset_filter(
+        table, "stop_reason_concept_id", criteria.stop_reason_concept, ctx
+    )
+    table = apply_codeset_filter(
+        table, "payer_source_concept_id", criteria.payer_source_concept, ctx
+    )
+    table = apply_codeset_filter(
+        table, "plan_source_concept_id", criteria.plan_source_concept, ctx
+    )
+    table = apply_codeset_filter(
+        table, "sponsor_source_concept_id", criteria.sponsor_source_concept, ctx
+    )
+    table = apply_codeset_filter(
+        table, "stop_reason_source_concept_id", criteria.stop_reason_source_concept, ctx
+    )
+
+    table, start_column, end_column = apply_user_defined_period(
+        table,
+        "payer_plan_period_start_date",
+        "payer_plan_period_end_date",
+        criteria.user_defined_period,
+    )
+
+    if criteria.first:
+        table = apply_first_event(table, start_column, "payer_plan_period_id")
+
+    events = standardize_output(
+        table,
+        primary_key="payer_plan_period_id",
+        start_column=start_column,
+        end_column=end_column,
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/pipeline.py
+++ b/circe/execution/builders/pipeline.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import ibis
+import ibis.common.exceptions as ibis_exc
+import ibis.expr.types as ir
+import polars as pl
+
+from ...cohortdefinition import CohortExpression
+from ..build_context import BuildContext
+from . import condition_era  # noqa: F401
+from . import condition_occurrence  # noqa: F401
+from . import death  # noqa: F401
+from . import device_exposure  # noqa: F401
+from . import dose_era  # noqa: F401
+from . import drug_era  # noqa: F401
+from . import drug_exposure  # noqa: F401
+from . import measurement  # noqa: F401
+from . import observation  # noqa: F401
+from . import observation_period  # noqa: F401
+from . import payer_plan_period  # noqa: F401
+from . import procedure_occurrence  # noqa: F401
+from . import specimen  # noqa: F401
+from . import visit_detail  # noqa: F401
+from . import visit_occurrence  # noqa: F401
+from .common import (
+    apply_end_strategy,
+    apply_observation_window,
+    collapse_events,
+    has_end_strategy,
+)
+from .groups import apply_criteria_group
+from .post_processing import apply_censor_window, apply_censoring, apply_inclusion_rules
+from .registry import build_events
+
+OUTPUT_SCHEMA = {
+    "person_id": pl.Int64,
+    "event_id": pl.Int64,
+    "start_date": pl.Datetime,
+    "end_date": pl.Datetime,
+    "visit_occurrence_id": pl.Int64,
+}
+
+
+def build_primary_events(expression: CohortExpression, ctx: BuildContext):
+    def _maybe_materialize(table: ir.Table, label: str) -> ir.Table:
+        return ctx.maybe_materialize(table, label=label, analyze=True)
+
+    primary = expression.primary_criteria
+    if primary is None or not primary.criteria_list:
+        return None
+    event_tables: list[ir.Table] = []
+    for criteria in primary.criteria_list:
+        table = build_events(criteria, ctx)
+        if table is None:
+            continue
+        event_tables.append(table)
+    if not event_tables:
+        return None
+    if ctx.should_materialize_stages():
+        materialized: list[ir.Table] = []
+        for idx, table in enumerate(event_tables, start=1):
+            materialized.append(
+                ctx.maybe_materialize(table, label=f"primary_src_{idx}", analyze=True)
+            )
+        event_tables = materialized
+    events = event_tables[0]
+    for table in event_tables[1:]:
+        events = events.union(table, distinct=False)
+    events = events.mutate(_source_event_id=events.event_id)
+    events = apply_observation_window(events, primary.observation_window, ctx)
+    events = _assign_primary_event_ids(events)
+    if _should_limit(primary.primary_limit):
+        events = _apply_result_limit(events, primary.primary_limit)
+
+    events = ctx.maybe_materialize(events, label="primary_events", analyze=True)
+
+    # Short-circuit the remainder of the pipeline when no primary events exist.
+    if ctx.should_materialize_stages():
+        try:
+            primary_count = events.count().execute()
+        except (ibis_exc.IbisError, RuntimeError, ValueError, TypeError):
+            primary_count = None
+        if primary_count == 0:
+            events = _drop_aux_columns(events)
+            return events.limit(0)
+
+    events = apply_criteria_group(events, expression.additional_criteria, ctx)
+    if expression.additional_criteria:
+        events = ctx.maybe_materialize(
+            events, label="additional_criteria", analyze=True
+        )
+
+    events = apply_inclusion_rules(events, expression.inclusion_rules, ctx)
+    if expression.inclusion_rules:
+        events = ctx.maybe_materialize(events, label="inclusion", analyze=True)
+    # Circe ignores QualifiedLimit, so we do the same to preserve parity.
+    if _should_limit(expression.expression_limit):
+        events = _apply_result_limit(events, expression.expression_limit)
+    events = apply_end_strategy(events, expression.end_strategy, ctx)
+    if has_end_strategy(expression.end_strategy):
+        events = _maybe_materialize(events, label="strategy_ends")
+
+    # Censoring should cut the cohort end date, so apply it after end strategy.
+    events = apply_censoring(events, expression.censoring_criteria, ctx)
+    if expression.censoring_criteria:
+        events = ctx.maybe_materialize(events, label="censoring", analyze=True)
+    events = apply_censor_window(events, expression.censor_window, ctx)
+    events = _drop_aux_columns(events)
+    events = collapse_events(events, expression.collapse_settings)
+    if expression.collapse_settings and expression.collapse_settings.collapse_type:
+        events = _maybe_materialize(events, label="final_cohort")
+    return events
+
+
+def build_primary_events_polars(
+    expression: CohortExpression, ctx: BuildContext
+) -> pl.DataFrame:
+    events = build_primary_events(expression, ctx)
+    if events is None:
+        return pl.DataFrame(schema=OUTPUT_SCHEMA)
+    return events.to_polars()
+
+
+def _assign_primary_event_ids(events):
+    if "_source_event_id" not in events.columns:
+        events = events.mutate(_source_event_id=events.event_id)
+    order = [events.person_id, events.start_date, events._source_event_id]
+    person_window = ibis.window(group_by=events.person_id, order_by=order[1:])
+    person_rank = ibis.row_number().over(person_window)
+    events = events.mutate(
+        # Keep event ids unique *within* a person to avoid global sorts/shuffles.
+        # Most downstream logic keys by (person_id, event_id).
+        event_id=(person_rank + 1),
+        _person_ordinal=(person_rank + 1),
+    )
+    supplemental = [
+        events[column]
+        for column in ("observation_period_start_date", "observation_period_end_date")
+        if column in events.columns
+    ]
+    return events.select(
+        events.person_id,
+        events.event_id,
+        events.start_date,
+        events.end_date,
+        events.visit_occurrence_id,
+        events._source_event_id,
+        events._person_ordinal,
+        *supplemental,
+    )
+
+
+def _apply_result_limit(events: ir.Table, limit) -> ir.Table:
+    if not limit or (limit.type or "ALL").lower() == "all":
+        return events
+
+    order_by = [events.start_date]
+    if "event_id" in events.columns:
+        order_by.append(events.event_id)
+
+    w = ibis.window(group_by=events.person_id, order_by=order_by)
+
+    helper = "__mitos_rn__"
+
+    ranked = events.mutate(**{helper: ibis.row_number().over(w)})
+    limited = ranked.filter(ranked[helper] == 0)
+
+    return limited.select([limited[c] for c in events.columns])
+
+
+def _drop_aux_columns(events: ir.Table) -> ir.Table:
+    drop_cols = [
+        col
+        for col in (
+            "_source_event_id",
+            "_person_ordinal",
+            "observation_period_start_date",
+            "observation_period_end_date",
+            "_result_row",
+        )
+        if col in events.columns
+    ]
+    if drop_cols:
+        events = events.drop(*drop_cols)
+    return events
+
+
+def _should_limit(limit) -> bool:
+    return bool(limit and (limit.type or "all").lower() != "all")

--- a/circe/execution/builders/post_processing.py
+++ b/circe/execution/builders/post_processing.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import ibis
+import ibis.expr.types as ir
+
+from ...cohortdefinition.criteria import Criteria, InclusionRule
+from ..build_context import BuildContext
+from .groups import apply_criteria_group
+from .registry import build_events
+
+
+def apply_additional_criteria(events: ir.Table, group, ctx: BuildContext) -> ir.Table:
+    return apply_criteria_group(events, group, ctx)
+
+
+def apply_inclusion_rules(
+    events: ir.Table, rules: list[InclusionRule], ctx: BuildContext
+) -> ir.Table:
+    if not rules:
+        return events
+
+    base_events = events.select(events.person_id, events.event_id)
+    bit_hits = []
+    used_bits: list[int] = []
+    for idx, rule in enumerate(rules):
+        rule_events = apply_criteria_group(events, rule.expression, ctx)
+        if rule_events is None:
+            continue
+        bit_value = 1 << idx
+        used_bits.append(bit_value)
+        bit_hits.append(
+            rule_events.select(
+                rule_events.person_id,
+                rule_events.event_id,
+                ibis.literal(bit_value, type="int64").name("_rule_bit"),
+            ).distinct()
+        )
+    if not bit_hits:
+        return events
+
+    union_hits = bit_hits[0]
+    for table in bit_hits[1:]:
+        union_hits = union_hits.union(table, distinct=False)
+
+    union_hits = ctx.maybe_materialize(union_hits, label="inclusion_hits", analyze=True)
+
+    mask = union_hits.group_by(union_hits.person_id, union_hits.event_id).aggregate(
+        # Postgres returns NUMERIC for SUM(BIGINT), which breaks bitwise ops.
+        # Ibis also infers SUM(int64) -> int64 and may optimize away an int64 cast,
+        # so we force an intermediate cast to keep the SQL-level cast.
+        _rule_mask=union_hits._rule_bit.sum()
+        .cast("decimal(38,0)")
+        .cast("int64")
+    )
+    target_mask = sum(used_bits)
+    target_literal = ibis.literal(target_mask, type="int64")
+    mask = mask.filter((mask._rule_mask & target_literal) == target_literal)
+
+    filtered_ids = base_events.inner_join(mask, ["person_id", "event_id"])
+    return events.inner_join(filtered_ids, ["person_id", "event_id"]).select(
+        events.columns
+    )
+
+
+def apply_censoring(
+    events: ir.Table, criteria_list: list[Criteria], ctx: BuildContext
+) -> ir.Table:
+    if not criteria_list:
+        return events
+    censor_tables = [
+        build_events(criteria, ctx) for criteria in criteria_list if criteria
+    ]
+    if not censor_tables:
+        return events
+    censor_events = censor_tables[0]
+    for table in censor_tables[1:]:
+        censor_events = censor_events.union(table)
+
+    censor_events = censor_events.select(
+        censor_events.person_id,
+        censor_events.start_date.name("censor_start"),
+    )
+    joined = events.join(
+        censor_events,
+        (events.person_id == censor_events.person_id)
+        & (censor_events.censor_start >= events.start_date),
+        how="left",
+    )
+    min_censor = joined.group_by(joined.person_id, joined.event_id).aggregate(
+        censor_date=joined.censor_start.min()
+    )
+    event_columns = events.columns
+    events = events.left_join(
+        min_censor,
+        (events.person_id == min_censor.person_id)
+        & (events.event_id == min_censor.event_id),
+    )
+    events = events.select(*event_columns, min_censor.censor_date)
+    events = events.mutate(
+        end_date=ibis.ifelse(
+            events.censor_date.notnull() & (events.censor_date < events.end_date),
+            events.censor_date,
+            events.end_date,
+        )
+    ).select(*event_columns)
+    return events
+
+
+def apply_censor_window(events: ir.Table, window, ctx: BuildContext) -> ir.Table:
+    if not window:
+        return events
+    if window.start_date:
+        events = events.filter(events.start_date >= ibis.timestamp(window.start_date))
+    if window.end_date:
+        events = events.filter(events.end_date <= ibis.timestamp(window.end_date))
+    return events

--- a/circe/execution/builders/procedure_occurrence.py
+++ b/circe/execution/builders/procedure_occurrence.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import ProcedureOccurrence
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    apply_visit_concept_filters,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("ProcedureOccurrence")
+def build_procedure_occurrence(criteria: ProcedureOccurrence, ctx: BuildContext):
+    table = ctx.table("procedure_occurrence")
+
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="procedure_type_concept_id",
+        concepts=criteria.procedure_type,
+        selection=criteria.procedure_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.procedure_type_exclude),
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="modifier_concept_id",
+        concepts=criteria.modifier,
+        selection=criteria.modifier_cs,
+        ctx=ctx,
+    )
+
+    table = apply_numeric_range(table, "quantity", criteria.quantity)
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        getattr(criteria, "provider_specialty", None),
+        getattr(criteria, "provider_specialty_cs", None),
+        ctx,
+        provider_column="provider_id",
+    )
+    table = apply_visit_concept_filters(
+        table, criteria.visit_type, criteria.visit_type_cs, ctx
+    )
+
+    if criteria.procedure_source_concept is not None:
+        table = apply_codeset_filter(
+            table, "procedure_source_concept_id", criteria.procedure_source_concept, ctx
+        )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/registry.py
+++ b/circe/execution/builders/registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from typing import Dict
+
+import ibis.expr.types as ir
+
+from ...cohortdefinition.criteria import Criteria
+from ..build_context import BuildContext
+
+_REGISTRY: Dict[str, Callable[[Criteria, BuildContext], ir.Table]] = {}
+
+
+def register(criteria_name: str):
+    def decorator(func: Callable[[Criteria, BuildContext], ir.Table]):
+        _REGISTRY[criteria_name] = func
+        return func
+
+    return decorator
+
+
+def get_builder(criteria: Criteria):
+    name = criteria.__class__.__name__
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise ValueError(f"No builder registered for criteria {name}") from exc
+
+
+def build_events(criteria: Criteria, ctx: BuildContext) -> ir.Table:
+    builder = get_builder(criteria)
+    table = builder(criteria, ctx)
+    cache_key, label = _criteria_cache_key(criteria)
+    return ctx.get_or_materialize_slice(cache_key, table, label=label)
+
+
+def _criteria_cache_key(criteria: Criteria) -> tuple[str, str]:
+    payload = criteria.model_dump_json(
+        by_alias=True,
+        exclude_defaults=False,
+        exclude_none=False,
+    )
+    raw_key = f"{criteria.__class__.__name__}:{payload}"
+    digest = hashlib.sha1(raw_key.encode("utf-8")).hexdigest()[:8]
+    label = f"{criteria.__class__.__name__.lower()}_{digest}"
+    return raw_key, label

--- a/circe/execution/builders/specimen.py
+++ b/circe/execution/builders/specimen.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import Specimen
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_text_filter,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("Specimen")
+def build_specimen(criteria: Specimen, ctx: BuildContext):
+    table = ctx.table("specimen")
+
+    table = apply_codeset_filter(table, "specimen_concept_id", criteria.codeset_id, ctx)
+    table = apply_date_range(table, "specimen_date", criteria.occurrence_start_date)
+
+    table = apply_concept_criteria(
+        table,
+        column="specimen_type_concept_id",
+        concepts=criteria.specimen_type,
+        selection=criteria.specimen_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.specimen_type_exclude),
+    )
+
+    table = apply_numeric_range(table, "quantity", criteria.quantity)
+
+    table = apply_concept_criteria(
+        table,
+        column="unit_concept_id",
+        concepts=criteria.unit,
+        selection=criteria.unit_cs,
+        ctx=ctx,
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="anatomic_site_concept_id",
+        concepts=criteria.anatomic_site,
+        selection=criteria.anatomic_site_cs,
+        ctx=ctx,
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="disease_status_concept_id",
+        concepts=criteria.disease_status,
+        selection=criteria.disease_status_cs,
+        ctx=ctx,
+    )
+
+    table = apply_text_filter(table, "specimen_source_id", criteria.source_id)
+    if criteria.specimen_source_concept is not None:
+        table = apply_codeset_filter(
+            table,
+            "specimen_source_concept_id",
+            criteria.specimen_source_concept,
+            ctx,
+        )
+
+    if criteria.age:
+        table = apply_age_filter(table, criteria.age, ctx, "specimen_date")
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    if criteria.first:
+        table = apply_first_event(table, "specimen_date", "specimen_id")
+
+    events = standardize_output(
+        table,
+        primary_key="specimen_id",
+        start_column="specimen_date",
+        end_column="specimen_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/visit_detail.py
+++ b/circe/execution/builders/visit_detail.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import VisitDetail
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_care_site_filter,
+    apply_codeset_filter,
+    apply_concept_set_selection,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_interval_range,
+    apply_location_region_filter,
+    apply_provider_specialty_filter,
+    project_event_columns,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("VisitDetail")
+def build_visit_detail(criteria: VisitDetail, ctx: BuildContext):
+    table = ctx.table("visit_detail")
+
+    table = apply_codeset_filter(
+        table, "visit_detail_concept_id", criteria.codeset_id, ctx
+    )
+    if criteria.first:
+        table = apply_first_event(table, "visit_detail_start_date", "visit_detail_id")
+    table = apply_date_range(
+        table, "visit_detail_start_date", criteria.visit_detail_start_date
+    )
+    table = apply_date_range(
+        table, "visit_detail_end_date", criteria.visit_detail_end_date
+    )
+    table = apply_concept_set_selection(
+        table, "visit_detail_type_concept_id", criteria.visit_detail_type_cs, ctx
+    )
+    if criteria.visit_detail_source_concept is not None:
+        table = apply_codeset_filter(
+            table,
+            "visit_detail_source_concept_id",
+            criteria.visit_detail_source_concept,
+            ctx,
+        )
+    table = apply_interval_range(
+        table,
+        "visit_detail_start_date",
+        "visit_detail_end_date",
+        criteria.visit_detail_length,
+    )
+
+    if criteria.age:
+        table = apply_age_filter(table, criteria.age, ctx, "visit_detail_end_date")
+    table = apply_gender_filter(table, [], criteria.gender_cs, ctx)
+    table = apply_provider_specialty_filter(
+        table,
+        None,
+        criteria.provider_specialty_cs,
+        ctx,
+    )
+    table = apply_care_site_filter(table, criteria.place_of_service_cs, ctx)
+    table = apply_location_region_filter(
+        table,
+        care_site_column="care_site_id",
+        location_codeset_id=criteria.place_of_service_location,
+        start_column="visit_detail_start_date",
+        end_column="visit_detail_end_date",
+        ctx=ctx,
+    )
+
+    table = project_event_columns(
+        table,
+        primary_key="visit_detail_id",
+        start_column="visit_detail_start_date",
+        end_column="visit_detail_end_date",
+        include_visit_occurrence=True,
+    )
+
+    events = standardize_output(
+        table,
+        primary_key="visit_detail_id",
+        start_column="visit_detail_start_date",
+        end_column="visit_detail_end_date",
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/builders/visit_occurrence.py
+++ b/circe/execution/builders/visit_occurrence.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from ...cohortdefinition.criteria import VisitOccurrence
+from ..build_context import BuildContext
+from .common import (
+    apply_age_filter,
+    apply_codeset_filter,
+    apply_concept_criteria,
+    apply_date_range,
+    apply_first_event,
+    apply_gender_filter,
+    apply_numeric_range,
+    apply_provider_specialty_filter,
+    project_event_columns,
+    standardize_output,
+)
+from .groups import apply_criteria_group
+from .registry import register
+
+
+@register("VisitOccurrence")
+def build_visit_occurrence(criteria: VisitOccurrence, ctx: BuildContext):
+    table = ctx.table("visit_occurrence")
+
+    concept_column = criteria.get_concept_id_column()
+    table = apply_codeset_filter(table, concept_column, criteria.codeset_id, ctx)
+
+    table = apply_date_range(
+        table, criteria.get_start_date_column(), criteria.occurrence_start_date
+    )
+    table = apply_date_range(
+        table, criteria.get_end_date_column(), criteria.occurrence_end_date
+    )
+
+    table = apply_concept_criteria(
+        table,
+        column="visit_type_concept_id",
+        concepts=criteria.visit_type,
+        selection=criteria.visit_type_cs,
+        ctx=ctx,
+        exclude=bool(criteria.visit_type_exclude),
+    )
+
+    table = apply_provider_specialty_filter(
+        table,
+        criteria.provider_specialty,
+        criteria.provider_specialty_cs,
+        ctx,
+    )
+    table = apply_concept_criteria(
+        table,
+        column="place_of_service_concept_id",
+        concepts=criteria.place_of_service,
+        selection=criteria.place_of_service_cs,
+        ctx=ctx,
+    )
+    if criteria.visit_length:
+        table = apply_numeric_range(table, "visit_length", criteria.visit_length)
+
+    if criteria.age:
+        table = apply_age_filter(
+            table, criteria.age, ctx, criteria.get_start_date_column()
+        )
+    table = apply_gender_filter(table, criteria.gender, criteria.gender_cs, ctx)
+
+    if criteria.visit_source_concept is not None:
+        table = apply_codeset_filter(
+            table, "visit_source_concept_id", criteria.visit_source_concept, ctx
+        )
+
+    if criteria.first:
+        table = apply_first_event(
+            table, criteria.get_start_date_column(), criteria.get_primary_key_column()
+        )
+
+    table = project_event_columns(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+        include_visit_occurrence=True,
+    )
+
+    events = standardize_output(
+        table,
+        primary_key=criteria.get_primary_key_column(),
+        start_column=criteria.get_start_date_column(),
+        end_column=criteria.get_end_date_column(),
+    )
+    return apply_criteria_group(events, criteria.correlated_criteria, ctx)

--- a/circe/execution/criteria_compat.py
+++ b/circe/execution/criteria_compat.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any
+
+from ..cohortdefinition.criteria import (
+    ConditionEra,
+    ConditionOccurrence,
+    CorelatedCriteria,
+    Criteria,
+    Death,
+    DemographicCriteria,
+    DeviceExposure,
+    DoseEra,
+    DrugEra,
+    DrugExposure,
+    Measurement,
+    Observation,
+    ObservationPeriod,
+    PayerPlanPeriod,
+    ProcedureOccurrence,
+    Specimen,
+    VisitDetail,
+    VisitOccurrence,
+)
+
+CorrelatedCriteria = CorelatedCriteria
+DemoGraphicCriteria = DemographicCriteria
+
+
+class OccurrenceType(IntEnum):
+    EXACTLY = 0
+    AT_MOST = 1
+    AT_LEAST = 2
+
+
+_CONCEPT_ID_OVERRIDES: dict[str, str] = {
+    "Death": "cause_concept_id",
+    "DoseEra": "drug_concept_id",
+    "VisitDetail": "visit_detail_concept_id",
+}
+
+_PRIMARY_KEY_OVERRIDES: dict[str, str] = {
+    "Death": "person_id",
+}
+
+_START_DATE_OVERRIDES: dict[str, str] = {
+    "ConditionEra": "condition_era_start_date",
+    "DrugExposure": "drug_exposure_start_date",
+    "Measurement": "measurement_date",
+    "Observation": "observation_date",
+    "DeviceExposure": "device_exposure_start_date",
+    "ProcedureOccurrence": "procedure_date",
+    "DrugEra": "drug_era_start_date",
+    "DoseEra": "dose_era_start_date",
+    "ObservationPeriod": "observation_period_start_date",
+    "Specimen": "specimen_date",
+    "Death": "death_date",
+    "VisitDetail": "visit_detail_start_date",
+    "PayerPlanPeriod": "payer_plan_period_start_date",
+}
+
+_END_DATE_OVERRIDES: dict[str, str] = {
+    "ConditionEra": "condition_era_end_date",
+    "DrugExposure": "drug_exposure_end_date",
+    "Measurement": "measurement_date",
+    "Observation": "observation_date",
+    "DeviceExposure": "device_exposure_end_date",
+    "ProcedureOccurrence": "procedure_date",
+    "DrugEra": "drug_era_end_date",
+    "DoseEra": "dose_era_end_date",
+    "ObservationPeriod": "observation_period_end_date",
+    "Specimen": "specimen_date",
+    "Death": "death_date",
+    "VisitDetail": "visit_detail_end_date",
+    "PayerPlanPeriod": "payer_plan_period_end_date",
+}
+
+
+def _to_snake_case(name: str) -> str:
+    output: list[str] = []
+    for idx, char in enumerate(name):
+        if char.isupper() and idx > 0:
+            output.append("_")
+        output.append(char.lower())
+    return "".join(output)
+
+
+def _snake_case_class_name(cls: type[Criteria]) -> str:
+    return _to_snake_case(cls.__name__)
+
+
+def _get_concept_id_column(self: Criteria) -> str:
+    cls_name = self.__class__.__name__
+    overridden = _CONCEPT_ID_OVERRIDES.get(cls_name)
+    if overridden:
+        return overridden
+    table_name = self.snake_case_class_name()
+    return f"{table_name.split('_')[0]}_concept_id"
+
+
+def _get_primary_key_column(self: Criteria) -> str:
+    cls_name = self.__class__.__name__
+    overridden = _PRIMARY_KEY_OVERRIDES.get(cls_name)
+    if overridden:
+        return overridden
+    return f"{self.snake_case_class_name()}_id"
+
+
+def _get_start_date_column(self: Criteria) -> str:
+    cls_name = self.__class__.__name__
+    overridden = _START_DATE_OVERRIDES.get(cls_name)
+    if overridden:
+        return overridden
+    return f"{self.snake_case_class_name().split('_')[0]}_start_date"
+
+
+def _get_end_date_column(self: Criteria) -> str:
+    cls_name = self.__class__.__name__
+    overridden = _END_DATE_OVERRIDES.get(cls_name)
+    if overridden:
+        return overridden
+    return f"{self.snake_case_class_name().split('_')[0]}_end_date"
+
+
+def ensure_criteria_compat() -> None:
+    if getattr(Criteria, "_execution_compat_patched", False):
+        return
+
+    Criteria.snake_case_class_name = classmethod(_snake_case_class_name)
+    Criteria.get_concept_id_column = _get_concept_id_column
+    Criteria.get_primary_key_column = _get_primary_key_column
+    Criteria.get_start_date_column = _get_start_date_column
+    Criteria.get_end_date_column = _get_end_date_column
+    Criteria._execution_compat_patched = True
+
+
+CRITERIA_TYPE_MAP: dict[str, type[Criteria]] = {
+    "ConditionOccurrence": ConditionOccurrence,
+    "ConditionEra": ConditionEra,
+    "VisitOccurrence": VisitOccurrence,
+    "DrugExposure": DrugExposure,
+    "DrugEra": DrugEra,
+    "DoseEra": DoseEra,
+    "ObservationPeriod": ObservationPeriod,
+    "Measurement": Measurement,
+    "Observation": Observation,
+    "Specimen": Specimen,
+    "DeviceExposure": DeviceExposure,
+    "ProcedureOccurrence": ProcedureOccurrence,
+    "Death": Death,
+    "VisitDetail": VisitDetail,
+    "PayerPlanPeriod": PayerPlanPeriod,
+}
+CRITERIA_TYPE_MAP_CASEFOLD: dict[str, type[Criteria]] = {
+    name.casefold(): model for name, model in CRITERIA_TYPE_MAP.items()
+}
+
+
+def parse_single_criteria(criteria_dict: Any) -> Criteria:
+    if isinstance(criteria_dict, Criteria):
+        return criteria_dict
+
+    if not isinstance(criteria_dict, dict):
+        raise ValueError("Criteria wrapper must be an object.")
+
+    if len(criteria_dict) != 1:
+        raise ValueError("Criteria wrapper must contain exactly one criteria type key.")
+
+    criteria_type, criteria_data = next(iter(criteria_dict.items()))
+    model_cls = CRITERIA_TYPE_MAP.get(criteria_type)
+    if model_cls is None and isinstance(criteria_type, str):
+        model_cls = CRITERIA_TYPE_MAP_CASEFOLD.get(criteria_type.casefold())
+    if model_cls is None:
+        raise ValueError(f"Unsupported criteria type: {criteria_type}")
+
+    if criteria_data is None:
+        criteria_data = {}
+
+    if not isinstance(criteria_data, dict):
+        raise ValueError(f"Criteria payload for {criteria_type} must be an object.")
+
+    return model_cls.model_validate(criteria_data, strict=False)
+
+
+def parse_criteria_list(criteria_list_data: Any) -> list[Criteria]:
+    if criteria_list_data is None:
+        return []
+
+    if not isinstance(criteria_list_data, list):
+        raise ValueError("Criteria list must be a list.")
+
+    criteria_instances: list[Criteria] = []
+    for idx, criteria_dict in enumerate(criteria_list_data):
+        try:
+            parsed = parse_single_criteria(criteria_dict)
+        except ValueError as exc:
+            raise ValueError(f"Invalid criteria wrapper at index {idx}: {exc}") from exc
+        criteria_instances.append(parsed)
+    return criteria_instances
+
+
+ensure_criteria_compat()

--- a/circe/execution/ibis.py
+++ b/circe/execution/ibis.py
@@ -1,0 +1,221 @@
+"""Experimental ibis execution API."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from ..io import ExpressionInput, load_expression
+from .options import ExecutionOptions, SchemaName, schema_to_str
+
+if TYPE_CHECKING:
+    import ibis.expr.types as ir
+    import pandas as pd
+    import polars as pl
+
+
+class IbisExecutor:
+    """Execute cohort expressions against an ibis backend.
+
+    Notes:
+    - This API is experimental.
+    - `build()` returns an ibis table expression (lazy relation).
+    - Materialization happens in `to_polars()` / `to_pandas()` / `write()`.
+    """
+
+    def __init__(self, conn: Any, options: Optional[ExecutionOptions] = None):
+        self._conn = conn
+        self._options = options or ExecutionOptions()
+        self._open_contexts: List[Any] = []
+
+    @property
+    def conn(self) -> Any:
+        return self._conn
+
+    @property
+    def options(self) -> ExecutionOptions:
+        return self._options
+
+    def build(self, expression: ExpressionInput) -> Any:
+        """Build a lazy ibis relation for the final cohort rows."""
+        cohort_expression = load_expression(expression)
+        self.close()
+        return self._build_native(cohort_expression)
+
+    def to_polars(self, expression: ExpressionInput) -> "pl.DataFrame":
+        """Execute cohort expression and collect to Polars."""
+        table = self.build(expression)
+        if not hasattr(table, "to_polars"):
+            raise RuntimeError(
+                "The returned ibis table does not support to_polars() on this backend."
+            )
+        return table.to_polars()
+
+    def to_pandas(self, expression: ExpressionInput) -> "pd.DataFrame":
+        """Execute cohort expression and collect to pandas."""
+        table = self.build(expression)
+        if not hasattr(table, "to_pandas"):
+            raise RuntimeError(
+                "The returned ibis table does not support to_pandas() on this backend."
+            )
+        return table.to_pandas()
+
+    def write(
+        self,
+        expression: ExpressionInput,
+        *,
+        table: str,
+        schema: Optional[SchemaName] = None,
+        overwrite: bool = True,
+        append: bool = False,
+        cohort_id: Optional[int] = None,
+    ) -> Any:
+        """Persist cohort rows to a cohort table and return a backend table handle."""
+        cohort_expression = load_expression(expression)
+        self.close()
+        events, ctx = self._build_with_context_native(
+            cohort_expression, cohort_id_override=cohort_id
+        )
+        self._open_contexts.append(ctx)
+        return ctx.write_cohort_table(
+            events,
+            table_name=table,
+            database=schema_to_str(schema)
+            or schema_to_str(self._options.result_schema),
+            overwrite=overwrite,
+            append=append,
+        )
+
+    def captured_sql(self) -> List[tuple[str, str]]:
+        """Return captured staged SQL snippets when capture_sql is enabled."""
+        captured: List[tuple[str, str]] = []
+        for ctx in self._open_contexts:
+            if hasattr(ctx, "captured_sql"):
+                captured.extend(ctx.captured_sql())
+        return captured
+
+    def close(self) -> None:
+        """Release temporary resources held by execution contexts."""
+        while self._open_contexts:
+            ctx = self._open_contexts.pop()
+            try:
+                ctx.close()
+            except Exception as exc:
+                print(f"Warning: failed to close execution context: {exc}")
+
+    def __enter__(self) -> "IbisExecutor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def _build_native(self, cohort_expression: Any) -> Any:
+        events, ctx = self._build_with_context_native(cohort_expression)
+        self._open_contexts.append(ctx)
+        return events
+
+    def _build_with_context_native(
+        self, cohort_expression: Any, cohort_id_override: Optional[int] = None
+    ) -> Any:
+        try:
+            from .build_context import (
+                BuildContext,
+                CohortBuildOptions,
+                compile_codesets,
+            )
+            from .builders.pipeline import build_primary_events
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Ibis execution requires optional dependencies. "
+                "Install `ohdsi-circe-python-alpha[ibis]` plus a backend extra, "
+                "for example `[ibis-duckdb]`."
+            ) from exc
+
+        backend = self._infer_backend_name(self._conn)
+        options = CohortBuildOptions(
+            cdm_schema=schema_to_str(self._options.cdm_schema),
+            vocabulary_schema=schema_to_str(self._options.vocabulary_schema),
+            result_schema=schema_to_str(self._options.result_schema),
+            cohort_id=(
+                cohort_id_override
+                if cohort_id_override is not None
+                else self._options.cohort_id
+            ),
+            materialize_stages=self._options.materialize_stages,
+            materialize_codesets=self._options.materialize_codesets,
+            temp_emulation_schema=schema_to_str(self._options.temp_emulation_schema),
+            profile_dir=self._options.profile_dir,
+            capture_sql=self._options.capture_sql,
+            backend=backend,
+        )
+        resource = compile_codesets(
+            self._conn, cohort_expression.concept_sets or [], options
+        )
+        ctx = BuildContext(self._conn, options, resource)
+        events = build_primary_events(cohort_expression, ctx)
+        if events is None:
+            raise RuntimeError(
+                "No primary events were generated for the supplied cohort expression."
+            )
+        return events, ctx
+
+    @staticmethod
+    def _infer_backend_name(conn: Any) -> Optional[str]:
+        backend_name = getattr(conn, "name", None)
+        if isinstance(backend_name, str) and backend_name:
+            return backend_name.lower()
+        class_name = conn.__class__.__name__.lower()
+        if "duckdb" in class_name:
+            return "duckdb"
+        if "postgres" in class_name:
+            return "postgres"
+        if "databricks" in class_name:
+            return "databricks"
+        return None
+
+
+def build_ibis(
+    expression: ExpressionInput,
+    conn: Any,
+    options: Optional[ExecutionOptions] = None,
+) -> Any:
+    """Convenience wrapper for IbisExecutor.build()."""
+    with IbisExecutor(conn, options) as executor:
+        return executor.build(expression)
+
+
+def to_polars(
+    expression: ExpressionInput,
+    conn: Any,
+    options: Optional[ExecutionOptions] = None,
+) -> "pl.DataFrame":
+    """Convenience wrapper for IbisExecutor.to_polars()."""
+    with IbisExecutor(conn, options) as executor:
+        return executor.to_polars(expression)
+
+
+def write_cohort(
+    expression: ExpressionInput,
+    conn: Any,
+    *,
+    table: str,
+    schema: Optional[SchemaName] = None,
+    overwrite: bool = True,
+    append: bool = False,
+    cohort_id: Optional[int] = None,
+    options: Optional[ExecutionOptions] = None,
+) -> Any:
+    """Convenience wrapper for IbisExecutor.write()."""
+    effective_options = options
+    if cohort_id is not None:
+        effective_options = replace(options or ExecutionOptions(), cohort_id=cohort_id)
+
+    with IbisExecutor(conn, effective_options) as executor:
+        return executor.write(
+            expression,
+            table=table,
+            schema=schema,
+            overwrite=overwrite,
+            append=append,
+            cohort_id=cohort_id,
+        )

--- a/circe/execution/ibis.py
+++ b/circe/execution/ibis.py
@@ -71,6 +71,10 @@ class IbisExecutor:
         cohort_id: Optional[int] = None,
     ) -> Any:
         """Persist cohort rows to a cohort table and return a backend table handle."""
+        if append and overwrite:
+            raise ValueError(
+                "`append=True` and `overwrite=True` cannot be used together."
+            )
         cohort_expression = load_expression(expression)
         self.close()
         events, ctx = self._build_with_context_native(

--- a/circe/execution/ibis_compat.py
+++ b/circe/execution/ibis_compat.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import ibis
+import ibis.expr.operations as ops
+import ibis.expr.types as ir
+from ibis.common.collections import FrozenOrderedDict
+
+
+def table_from_literal_list(
+    values: Iterable[int],
+    *,
+    column_name: str,
+    element_type: str = "int64",
+) -> ir.Table:
+    """
+    Build a 1-column table from a Python list without using `ibis.memtable`.
+
+    This avoids Databricks' memtable upload machinery (which depends on a writable
+    Unity Catalog volume) while still producing a pure Ibis expression.
+    """
+    values_list = list(values)
+    if not values_list:
+        dummy = ops.DummyTable(
+            values=FrozenOrderedDict({column_name: ibis.null().cast(element_type).op()})
+        ).to_expr()
+        return dummy.select(dummy[column_name]).filter(ibis.literal(False))
+
+    array_type = f"array<{element_type}>"
+    arr = ibis.literal(values_list, type=array_type)
+
+    dummy = ops.DummyTable(values=FrozenOrderedDict({"__values__": arr.op()})).to_expr()
+    unnested = ops.TableUnnest(
+        dummy.op(),
+        dummy["__values__"].op(),
+        column_name,
+        None,
+        False,
+    ).to_expr()
+    return unnested.select(unnested[column_name])

--- a/circe/execution/options.py
+++ b/circe/execution/options.py
@@ -1,0 +1,38 @@
+"""Execution options for backend-native cohort execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+SchemaName = Union[str, Tuple[str, str]]
+
+
+@dataclass(frozen=True)
+class ExecutionOptions:
+    """Runtime options for backend execution via ibis.
+
+    This API is experimental and may evolve while execution parity is built out.
+    """
+
+    cdm_schema: Optional[SchemaName] = None
+    vocabulary_schema: Optional[SchemaName] = None
+    result_schema: Optional[SchemaName] = None
+
+    cohort_id: Optional[int] = None
+
+    materialize_stages: bool = False
+    materialize_codesets: bool = True
+    temp_emulation_schema: Optional[SchemaName] = None
+
+    capture_sql: bool = False
+    profile_dir: Optional[str] = None
+
+
+def schema_to_str(schema: Optional[SchemaName]) -> Optional[str]:
+    """Normalize schema names to a string representation."""
+    if schema is None:
+        return None
+    if isinstance(schema, tuple):
+        return ".".join(schema)
+    return schema

--- a/circe/io.py
+++ b/circe/io.py
@@ -1,0 +1,61 @@
+"""
+Input loading helpers for cohort expressions.
+
+This module provides a canonical loader used by execution-oriented APIs to
+accept either in-memory models or serialized payloads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Union
+
+from .api import cohort_expression_from_json
+from .cohortdefinition import CohortExpression
+
+ExpressionInput = Union[CohortExpression, Mapping[str, Any], str, Path]
+
+
+def load_expression(value: ExpressionInput) -> CohortExpression:
+    """Normalize different expression inputs into a CohortExpression.
+
+    Accepted inputs:
+    - CohortExpression
+    - mapping/dict compatible with CohortExpression
+    - JSON string
+    - path to a JSON file
+    """
+    if isinstance(value, CohortExpression):
+        return value
+
+    if isinstance(value, Mapping):
+        return CohortExpression.model_validate(dict(value))
+
+    if isinstance(value, Path):
+        return cohort_expression_from_json(value.read_text(encoding="utf-8"))
+
+    if isinstance(value, str):
+        stripped = value.strip()
+
+        # JSON payload path
+        if stripped.startswith("{") or stripped.startswith("["):
+            return cohort_expression_from_json(stripped)
+
+        # File-system path
+        path = Path(value)
+        if path.exists() and path.is_file():
+            return cohort_expression_from_json(path.read_text(encoding="utf-8"))
+
+        # If it wasn't an existing path, attempt JSON parse for clearer errors.
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "Expected JSON string or path to a JSON file for cohort expression input."
+            ) from exc
+        return CohortExpression.model_validate(parsed)
+
+    raise TypeError(
+        "Unsupported expression input type. Expected CohortExpression, mapping, JSON string, or Path."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,19 @@ docs = [
     "sphinx>=5.0.0",
     "sphinx-rtd-theme>=1.0.0",
 ]
+ibis = [
+    "ibis-framework>=9.0.0; python_version >= '3.9'",
+]
+ibis-duckdb = [
+    "ibis-framework[duckdb]>=9.0.0; python_version >= '3.9'",
+    "polars>=0.20.0; python_version >= '3.9'",
+]
+ibis-postgres = [
+    "ibis-framework[postgres]>=9.0.0; python_version >= '3.9'",
+]
+ibis-databricks = [
+    "ibis-framework[databricks]>=9.0.0; python_version >= '3.9'",
+]
 
 [project.urls]
 Homepage = "https://github.com/OHDSI/Circepy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,17 +54,17 @@ docs = [
     "sphinx-rtd-theme>=1.0.0",
 ]
 ibis = [
-    "ibis-framework>=9.0.0; python_version >= '3.9'",
+    "ibis-framework>=11.0.0; python_version >= '3.9'",
 ]
 ibis-duckdb = [
-    "ibis-framework[duckdb]>=9.0.0; python_version >= '3.9'",
+    "ibis-framework[duckdb]>=11.0.0; python_version >= '3.9'",
     "polars>=0.20.0; python_version >= '3.9'",
 ]
 ibis-postgres = [
-    "ibis-framework[postgres]>=9.0.0; python_version >= '3.9'",
+    "ibis-framework[postgres]>=11.0.0; python_version >= '3.9'",
 ]
 ibis-databricks = [
-    "ibis-framework[databricks]>=9.0.0; python_version >= '3.9'",
+    "ibis-framework[databricks]>=11.0.0; python_version >= '3.9'",
 ]
 
 [project.urls]

--- a/tests/test_execution_api.py
+++ b/tests/test_execution_api.py
@@ -19,6 +19,7 @@ from circe.cohortdefinition import (
 )
 from circe.execution import ExecutionOptions, IbisExecutor
 from circe.execution.criteria_compat import parse_single_criteria
+from circe.execution.ibis import write_cohort
 from circe.execution.options import schema_to_str
 from circe.io import load_expression
 from circe.vocabulary import Concept, ConceptSet, ConceptSetExpression, ConceptSetItem
@@ -117,6 +118,35 @@ def test_coerce_concept_set_selection_rejects_invalid_value():
 
     with pytest.raises(ValueError, match="Unsupported concept set selection value"):
         coerce_concept_set_selection(object())
+
+
+def test_write_rejects_append_and_overwrite_together():
+    class DummyConn:
+        pass
+
+    executor = IbisExecutor(DummyConn(), ExecutionOptions())
+
+    with pytest.raises(ValueError, match="cannot be used together"):
+        executor.write(
+            {"Title": "Invalid write options"},
+            table="cohort",
+            append=True,
+            overwrite=True,
+        )
+
+
+def test_write_cohort_rejects_append_and_overwrite_together():
+    class DummyConn:
+        pass
+
+    with pytest.raises(ValueError, match="cannot be used together"):
+        write_cohort(
+            {"Title": "Invalid write options"},
+            DummyConn(),
+            table="cohort",
+            append=True,
+            overwrite=True,
+        )
 
 
 def test_has_end_strategy_handles_polymorphic_models():

--- a/tests/test_execution_api.py
+++ b/tests/test_execution_api.py
@@ -1,0 +1,209 @@
+"""Tests for experimental execution API surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from circe import CohortExpression
+from circe.cohortdefinition import (
+    ConditionOccurrence,
+    CustomEraStrategy,
+    DateOffsetStrategy,
+    DrugExposure,
+    PayerPlanPeriod,
+    PrimaryCriteria,
+    VisitDetail,
+)
+from circe.execution import ExecutionOptions, IbisExecutor
+from circe.execution.criteria_compat import parse_single_criteria
+from circe.execution.options import schema_to_str
+from circe.io import load_expression
+from circe.vocabulary import Concept, ConceptSet, ConceptSetExpression, ConceptSetItem
+
+
+def test_execution_options_defaults():
+    options = ExecutionOptions()
+
+    assert options.cdm_schema is None
+    assert options.vocabulary_schema is None
+    assert options.result_schema is None
+    assert options.cohort_id is None
+    assert options.materialize_stages is False
+    assert options.materialize_codesets is True
+    assert options.temp_emulation_schema is None
+    assert options.capture_sql is False
+    assert options.profile_dir is None
+
+
+def test_schema_to_str_with_tuple_schema():
+    assert schema_to_str(("catalog", "schema")) == "catalog.schema"
+
+
+def test_load_expression_from_mapping():
+    expression = load_expression({"Title": "Mapping Input"})
+    assert isinstance(expression, CohortExpression)
+    assert expression.title == "Mapping Input"
+
+
+def test_load_expression_from_path(tmp_path: Path):
+    payload = {"Title": "File Input"}
+    path = tmp_path / "cohort.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    expression = load_expression(path)
+    assert isinstance(expression, CohortExpression)
+    assert expression.title == "File Input"
+
+
+def test_ibis_executor_missing_optional_dependencies(monkeypatch):
+    class DummyConn:
+        pass
+
+    import builtins
+    import sys
+
+    real_import = builtins.__import__
+    sys.modules.pop("circe.execution.build_context", None)
+
+    def _import(name, *args, **kwargs):
+        if name.endswith("build_context"):
+            raise ModuleNotFoundError("No module named 'ibis'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+    executor = IbisExecutor(DummyConn(), ExecutionOptions())
+
+    with pytest.raises(RuntimeError, match="requires optional dependencies"):
+        executor.build({"Title": "No Backend"})
+
+
+def test_criteria_compat_methods_available():
+    criteria = DrugExposure()
+
+    assert criteria.get_primary_key_column() == "drug_exposure_id"
+    assert criteria.get_start_date_column() == "drug_exposure_start_date"
+    assert criteria.get_end_date_column() == "drug_exposure_end_date"
+    assert criteria.get_concept_id_column() == "drug_concept_id"
+
+
+def test_parse_single_criteria_wrapper():
+    parsed = parse_single_criteria({"ConditionOccurrence": {"CodesetId": 10}})
+
+    assert isinstance(parsed, ConditionOccurrence)
+    assert parsed.codeset_id == 10
+
+
+def test_parse_single_criteria_wrapper_case_insensitive():
+    parsed = parse_single_criteria({"conditionoccurrence": {"CodesetId": 11}})
+
+    assert isinstance(parsed, ConditionOccurrence)
+    assert parsed.codeset_id == 11
+
+
+def test_pipeline_registers_visit_detail_and_payer_plan_period_builders():
+    from circe.execution.builders import pipeline as _pipeline  # noqa: F401
+    from circe.execution.builders.registry import get_builder
+
+    assert callable(get_builder(VisitDetail()))
+    assert callable(get_builder(PayerPlanPeriod()))
+
+
+def test_coerce_concept_set_selection_rejects_invalid_value():
+    from circe.execution.builders.common import coerce_concept_set_selection
+
+    with pytest.raises(ValueError, match="Unsupported concept set selection value"):
+        coerce_concept_set_selection(object())
+
+
+def test_has_end_strategy_handles_polymorphic_models():
+    from circe.execution.builders.common import has_end_strategy
+
+    assert has_end_strategy(None) is False
+    assert (
+        has_end_strategy(DateOffsetStrategy(offset=7, date_field="StartDate")) is True
+    )
+    assert has_end_strategy(CustomEraStrategy(drug_codeset_id=123)) is True
+
+
+def test_ibis_executor_build_smoke_duckdb():
+    ibis = pytest.importorskip("ibis")
+    _ = pytest.importorskip("duckdb")
+
+    conn = ibis.duckdb.connect()
+
+    conn.create_table(
+        "concept",
+        obj=ibis.memtable(
+            {
+                "concept_id": [111, 999],
+                "invalid_reason": [None, "D"],
+            }
+        ),
+        overwrite=True,
+    )
+    conn.create_table(
+        "concept_ancestor",
+        obj=ibis.memtable(
+            {
+                "ancestor_concept_id": [111],
+                "descendant_concept_id": [111],
+            }
+        ),
+        overwrite=True,
+    )
+    conn.create_table(
+        "concept_relationship",
+        obj=ibis.memtable(
+            {
+                "concept_id_1": [111],
+                "concept_id_2": [111],
+                "relationship_id": ["Maps to"],
+                "invalid_reason": [""],
+            }
+        ),
+        overwrite=True,
+    )
+    conn.create_table(
+        "condition_occurrence",
+        obj=ibis.memtable(
+            {
+                "person_id": [1],
+                "condition_occurrence_id": [1001],
+                "condition_concept_id": [111],
+                "condition_start_date": ["2020-01-01"],
+                "condition_end_date": ["2020-01-02"],
+            }
+        ),
+        overwrite=True,
+    )
+
+    cohort = CohortExpression(
+        concept_sets=[
+            ConceptSet(
+                id=1,
+                expression=ConceptSetExpression(
+                    items=[ConceptSetItem(concept=Concept(conceptId=111))]
+                ),
+            )
+        ],
+        primary_criteria=PrimaryCriteria(
+            criteria_list=[ConditionOccurrence(codeset_id=1)],
+        ),
+    )
+
+    with IbisExecutor(conn, ExecutionOptions(materialize_stages=False)) as executor:
+        events = executor.build(cohort)
+        result = events.execute()
+
+    assert len(result) == 1
+    assert set(result.columns) == {
+        "person_id",
+        "event_id",
+        "start_date",
+        "end_date",
+        "visit_occurrence_id",
+    }

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -5,103 +5,121 @@ These tests verify that the package can be imported and basic structure is in pl
 """
 
 import pytest
+
 import circe
 
 
 class TestPackageStructure:
     """Test basic package structure and imports."""
-    
+
     def test_package_import(self):
         """Test that the main package can be imported."""
-        assert hasattr(circe, '__version__')
-    
+        assert hasattr(circe, "__version__")
+
     def test_package_metadata(self):
         """Test package metadata."""
-        assert hasattr(circe, '__author__')
-        assert hasattr(circe, '__email__')
-        assert hasattr(circe, '__license__')
+        assert hasattr(circe, "__author__")
+        assert hasattr(circe, "__email__")
+        assert hasattr(circe, "__license__")
         assert circe.__author__ == "CIRCE Python Implementation Team"
         assert circe.__email__ == "circe-python@ohdsi.org"
         assert circe.__license__ == "Apache License 2.0"
-    
+
     def test_subpackage_imports(self):
         """Test that subpackages can be imported."""
-        import circe.cohortdefinition
-        import circe.vocabulary
         import circe.check
-        import circe.helper
-        
-        # Test sub-subpackages
-        import circe.cohortdefinition.builders
-        import circe.cohortdefinition.printfriendly
         import circe.check.checkers
         import circe.check.operations
         import circe.check.utils
         import circe.check.warnings
-    
+        import circe.cohortdefinition
+
+        # Test sub-subpackages
+        import circe.cohortdefinition.builders
+        import circe.cohortdefinition.printfriendly
+        import circe.execution
+        import circe.helper
+        import circe.vocabulary
+
     def test_package_structure(self):
         """Test that package structure matches expected layout."""
         import circe
-        
+
         # Check that main package has expected attributes
-        expected_attrs = ['__version__', '__author__', '__email__', '__license__']
+        expected_attrs = ["__version__", "__author__", "__email__", "__license__"]
         for attr in expected_attrs:
             assert hasattr(circe, attr), f"Missing attribute: {attr}"
-    
+
     def test_main_exports(self):
         """Test that main classes are properly exported."""
         # These should be available at the package level
-        assert hasattr(circe, '__all__')
+        assert hasattr(circe, "__all__")
         assert isinstance(circe.__all__, list)
-        
+
         # Should include metadata and main classes
         expected_exports = [
-            "__version__", "__author__", "__email__", "__license__",
-            "CohortExpression", "Concept", "ConceptSet", 
-            "ConceptSetExpression", "ConceptSetItem"
+            "__version__",
+            "__author__",
+            "__email__",
+            "__license__",
+            "CohortExpression",
+            "Concept",
+            "ConceptSet",
+            "ConceptSetExpression",
+            "ConceptSetItem",
         ]
-        
+
         for export in expected_exports:
             assert export in circe.__all__, f"Missing export: {export}"
-        
+
     def test_main_class_imports(self):
         """Test that main classes can be imported and instantiated."""
         # Test that classes are available at package level
-        from circe import CohortExpression, Concept, ConceptSet, ConceptSetExpression, ConceptSetItem
-        
+        from circe import (
+            CohortExpression,
+            Concept,
+            ConceptSet,
+            ConceptSetExpression,
+            ConceptSetItem,
+        )
+
         # Test basic instantiation
         concept = Concept(conceptId=12345)
         assert concept.concept_id == 12345
-        
+
         concept_set = ConceptSet(id=1)
         assert concept_set.id == 1
-        
+
         cohort_expr = CohortExpression(title="Test")
         assert cohort_expr.title == "Test"
 
 
 class TestModuleStructure:
     """Test individual module structure."""
-    
+
     def test_cohortdefinition_module(self):
         """Test cohortdefinition module structure."""
         import circe.cohortdefinition
-        assert hasattr(circe.cohortdefinition, '__all__')
-    
+
+        assert hasattr(circe.cohortdefinition, "__all__")
+
     def test_vocabulary_module(self):
         """Test vocabulary module structure."""
         import circe.vocabulary
-        assert hasattr(circe.vocabulary, '__all__')
-    
+
+        assert hasattr(circe.vocabulary, "__all__")
+
     def test_check_module(self):
         """Test check module structure."""
         import circe.check
-        assert hasattr(circe.check, '__all__')
-    
+
+        assert hasattr(circe.check, "__all__")
+
     def test_helper_module(self):
         """Test helper module structure."""
         import circe.helper
-        assert hasattr(circe.helper, '__all__')
+
+        assert hasattr(circe.helper, "__all__")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Implements an experimental native Ibis execution API for Circepy with lazy relation building and
  explicit materialization actions.

  - Adds IbisExecutor with build(), to_pandas(), to_polars(), and write() methods
  - Adds convenience wrappers: build_ibis, to_polars, write_cohort
  - Introduces ExecutionOptions for execution/schema/materialization/SQL-capture controls
  - Ports and simplifies executor logic from Mitos into Circepy where I used like a registry-based factory  
  - Adds tests for API behavior and write-option validation
  - Validated DuckDB parity against CirceR row counts across phenotype-library cohorts (local integration
    run)


Sorry for how large this is.  The API is in circe/execution/ibis.py

There is some stuff in there I'm not completely satisifed with, but good enough for you to have a look @azimov 