### PR TITLE
fix: keep base package importable without ibis

### DIFF
--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -35,3 +35,30 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  wheel-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build wheel setuptools
+
+      - name: Build wheel
+        run: python -m build
+
+      - name: Smoke test installed wheel
+        run: |
+          python -m venv /tmp/circe-wheel-smoke
+          /tmp/circe-wheel-smoke/bin/pip install dist/*.whl
+          /tmp/circe-wheel-smoke/bin/circe --help
+          /tmp/circe-wheel-smoke/bin/python -c "import circe; print(circe.__version__)"

--- a/circe/api.py
+++ b/circe/api.py
@@ -9,7 +9,7 @@ This module provides a simple R CirceR-style API for working with cohort definit
 - cohort_print_friendly(): Generate Markdown from cohort expression
 """
 
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from .cohortdefinition import (
     BuildExpressionQueryOptions,
@@ -17,8 +17,13 @@ from .cohortdefinition import (
     CohortExpressionQueryBuilder,
     MarkdownRender,
 )
-from .execution.typing import IbisBackendLike, Table
 from .vocabulary.concept import ConceptSet
+
+if TYPE_CHECKING:
+    from .execution.typing import IbisBackendLike, Table
+else:
+    IbisBackendLike = Any
+    Table = Any
 
 
 def cohort_expression_from_json(json_str: str) -> CohortExpression:


### PR DESCRIPTION
@azimov , 

I just broke the nightly wheel build on develop. Because of importing stuff that needed ibis in api.py. I've fixed it in this and added a quick additional CI test that would expose this before merging PRs so this doesn't happen again.